### PR TITLE
ValueTuple workaround.

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
@@ -7,6 +7,7 @@ using LibGit2Sharp;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl.UnitTests;
 using Xunit;
+using static Microsoft.Build.Tasks.SourceControl.UnitTests.KeyValuePairUtils;
 
 namespace Microsoft.Build.Tasks.Git.UnitTests
 {
@@ -34,8 +35,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
               (string.IsNullOrEmpty(sourceLinkUrl) ? "" : $" SourceLinkUrl='{sourceLinkUrl}'");
         }
 
-        private static string InspectDiagnostic((string message, object[] args) warning)
-            => string.Format(warning.message, warning.args);
+        private static string InspectDiagnostic(KeyValuePair<string, object[]> warning)
+            => string.Format(warning.Key, warning.Value);
 
         [Fact]
         public void GetRevisionId_RepoWithoutCommits()
@@ -158,8 +159,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         {
             var repo = new TestRepository(workingDir: s_root, commitSha: null);
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             Assert.Empty(items);
             AssertEx.Equal(new[] { Resources.RepositoryWithoutCommit_SourceLink }, warnings.Select(InspectDiagnostic));
@@ -177,8 +178,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     new TestSubmodule("1", "sub/2", "http://2.com", "2222222222222222222222222222222222222222")
                 });
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             AssertEx.Equal(new[]
             {
@@ -201,8 +202,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     new TestSubmodule("1", "sub/2", "http://2.com", "2222222222222222222222222222222222222222")
                 });
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             AssertEx.Equal(new[]
             {
@@ -225,8 +226,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     new TestSubmodule("2", "sub/2", "../a", "2222222222222222222222222222222222222222"),
                 });
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             AssertEx.Equal(new[]
             {
@@ -250,8 +251,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     new TestSubmodule("2", "sub/2", "../a", "2222222222222222222222222222222222222222"),
                 });
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             AssertEx.Equal(new[]
             {
@@ -276,8 +277,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     new TestSubmodule("3", "sub/3", "http://3.com", "3333333333333333333333333333333333333333"),
                 });
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             AssertEx.Equal(new[]
             {
@@ -301,8 +302,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                 config: new Dictionary<string, object> { { "core.gvfs", true } },
                 submodulesSupported: false);
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: _ => false);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: _ => false);
 
             AssertEx.Equal(new[]
             {
@@ -334,8 +335,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     new TestSubmodule("1", "sub/1", "http://1.com/", "1111111111111111111111111111111111111111"),
                 });
 
-            var warnings = new List<(string message, object[] args)>();
-            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add((message, args)), fileExists: null);
+            var warnings = new List<KeyValuePair<string, object[]>>();
+            var items = GitOperations.GetSourceRoots(repo, (message, args) => warnings.Add(KVP(message, args)), fileExists: null);
 
             AssertEx.Equal(new[]
             {

--- a/src/Microsoft.Build.Tasks.SourceControl.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/Microsoft.Build.Tasks.SourceControl.UnitTests/GenerateSourceLinkFileTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using Xunit;
+using static Microsoft.Build.Tasks.SourceControl.UnitTests.KeyValuePairUtils;
 
 namespace Microsoft.Build.Tasks.SourceControl.UnitTests
 {
@@ -33,13 +34,12 @@ namespace Microsoft.Build.Tasks.SourceControl.UnitTests
         public void Escape()
         {
             var engine = new MockEngine();
-
             var task = new GenerateSourceLinkFile()
             {
                 BuildEngine = engine,
                 SourceRoots = new[]
                 {
-                    new MockItem(@"/_""_/", ("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), ("SourceControl", "git")),
+                    new MockItem(@"/_""_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
                 },
             };
 
@@ -59,9 +59,9 @@ namespace Microsoft.Build.Tasks.SourceControl.UnitTests
                 BuildEngine = engine,
                 SourceRoots = new[]
                 {
-                    new MockItem(@"C:\src\", ("SourceLinkUrl", "https://raw.githubusercontent.com/repo1/*"), ("SourceControl", "git")),
-                    new MockItem(@"C:\x\a\", ("SourceLinkUrl", "https://raw.githubusercontent.com/repo2/*"), ("SourceControl", "git")),
-                    new MockItem(@"C:\x\b\", ("SourceLinkUrl", "https://raw.githubusercontent.com/repo3/*"), ("SourceControl", "git")),
+                    new MockItem(@"C:\src\", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo1/*"), KVP("SourceControl", "git")),
+                    new MockItem(@"C:\x\a\", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo2/*"), KVP("SourceControl", "git")),
+                    new MockItem(@"C:\x\b\", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo3/*"), KVP("SourceControl", "git")),
                 },
             };
 
@@ -85,9 +85,9 @@ namespace Microsoft.Build.Tasks.SourceControl.UnitTests
                 BuildEngine = engine,
                 SourceRoots = new[] 
                 {
-                    new MockItem(@"C:\src\", ("MappedPath", "/_/"), ("SourceLinkUrl", "https://raw.githubusercontent.com/repo1/*"), ("SourceControl", "git")),
-                    new MockItem(@"C:\x\a\", ("MappedPath", "/_/1/"), ("SourceLinkUrl", "https://raw.githubusercontent.com/repo2/*"), ("SourceControl", "git")),
-                    new MockItem(@"C:\x\b\", ("MappedPath", "/_/2/"), ("SourceLinkUrl", "https://raw.githubusercontent.com/repo3/*"), ("SourceControl", "git")),
+                    new MockItem(@"C:\src\", KVP("MappedPath", "/_/"), KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo1/*"), KVP("SourceControl", "git")),
+                    new MockItem(@"C:\x\a\", KVP("MappedPath", "/_/1/"), KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo2/*"), KVP("SourceControl", "git")),
+                    new MockItem(@"C:\x\b\", KVP("MappedPath", "/_/2/"), KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo3/*"), KVP("SourceControl", "git")),
                 },
             };
 
@@ -112,7 +112,7 @@ namespace Microsoft.Build.Tasks.SourceControl.UnitTests
                 SourceRoots = new[]
                 {
                     // error: missing SourceLinkUrl in source-controlled root:
-                    new MockItem(@"C:\src\", ("SourceControl", "git")),
+                    new MockItem(@"C:\src\", KVP("SourceControl", "git")),
 
                     // skipped: missing SourceLinkUrl in non-source-controlled root
                     new MockItem(@"C:\x\a\"),
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Tasks.SourceControl.UnitTests
                     new MockItem(@"C:\x\c"),
 
                     // error: multiple *'s in url
-                    new MockItem(@"C:\x\d\", ("SourceLinkUrl", "http://a/**")),
+                    new MockItem(@"C:\x\d\", KVP("SourceLinkUrl", "http://a/**")),
                 },
             };
 

--- a/src/TestUtilities/KeyValuePairUtils.cs
+++ b/src/TestUtilities/KeyValuePairUtils.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.Tasks.SourceControl.UnitTests
+{
+    public static class KeyValuePairUtils
+    {
+        public static KeyValuePair<T1, T2> KVP<T1, T2>(T1 item1, T2 item2)
+            => new KeyValuePair<T1, T2>(item1, item2);
+
+        public static void Deconstruct<T1, T2>(this KeyValuePair<T1, T2> kvp, out T1 item1, out T2 item2)
+        {
+            item1 = kvp.Key;
+            item2 = kvp.Value;
+        }
+    }
+}

--- a/src/TestUtilities/MockItem.cs
+++ b/src/TestUtilities/MockItem.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Tasks.SourceControl.UnitTests
         public static string AdjustSeparators(string path)
             => Path.DirectorySeparatorChar == '/' ? path.Replace('\\', '/') : path;
 
-        public MockItem(string spec, params (string, string)[] metadata)
+        public MockItem(string spec, params KeyValuePair<string, string>[] metadata)
         {
             // msbuild normalizes paths on non-Windows like so:
             ItemSpec = AdjustSeparators(spec);


### PR DESCRIPTION
Workarounds a bug in .NET Framework 4.7.0 used by official build machines.