### PR TITLE
Remove unnecessary net461 libs and implement AssemblyResolve event.

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.Operations/Microsoft.Build.Tasks.Git.nuspec
+++ b/src/Microsoft.Build.Tasks.Git.Operations/Microsoft.Build.Tasks.Git.nuspec
@@ -28,13 +28,28 @@
 
     <file src="net461\Microsoft.Build.Tasks.Git.*" target="tools\net461" />
     <file src="net461\**\Microsoft.Build.Tasks.Git.resources.dll" target="tools\net461" />
-    <file src="net461\System.*" target="tools\net461" />
-    <file src="net461\Microsoft.Win32.Primitives.*" target="tools\net461" />
-    <file src="net461\netstandard.*" target="tools\net461" />
     <file src="net461\LibGit2Sharp.*" target="tools\net461" />
     <file src="net461\lib\**\*.dll" target="tools\net461\lib" />
     <file src="net461\lib\**\*.so" target="tools\net461\lib" />
     <file src="net461\lib\**\*.dylib" target="tools\net461\lib" />
+
+    <!-- Include netstandard and its dependencies that were copied by msbuild to the net461 directory -->
+    <file src="net461\netstandard.dll" target="tools\net461" />
+    <file src="net461\System.Data.Common.dll" target="tools\net461" />
+    <file src="net461\System.Diagnostics.StackTrace.dll" target="tools\net461" />
+    <file src="net461\System.Diagnostics.Tracing.dll" target="tools\net461" />
+    <file src="net461\System.Globalization.Extensions.dll" target="tools\net461" />
+    <file src="net461\System.IO.Compression.dll" target="tools\net461" />
+    <file src="net461\System.Net.Http.dll" target="tools\net461" />
+    <file src="net461\System.Net.Sockets.dll" target="tools\net461" />
+    <file src="net461\System.ValueTuple.dll" target="tools\net461" />
+    <file src="net461\System.Runtime.InteropServices.RuntimeInformation.dll" target="tools\net461" />
+    <file src="net461\System.Runtime.Serialization.Xml.dll" target="tools\net461" />
+    <file src="net461\System.Runtime.Serialization.Primitives.dll" target="tools\net461" />
+    <file src="net461\System.Security.Cryptography.Algorithms.dll" target="tools\net461" />
+    <file src="net461\System.Security.SecureString.dll" target="tools\net461" />
+    <file src="net461\System.Threading.Overlapped.dll" target="tools\net461" />
+    <file src="net461\System.Xml.XPath.XDocument.dll" target="tools\net461" />
 
     <file src="$ProjectDirectory$\build\*.*" target="build" />
     <file src="$ProjectDirectory$\build\*.*" target="buildCrossTargeting" />

--- a/src/Microsoft.Build.Tasks.Git/TaskImplementation.cs
+++ b/src/Microsoft.Build.Tasks.Git/TaskImplementation.cs
@@ -14,14 +14,21 @@ namespace Microsoft.Build.Tasks.Git
         public static Func<GetSourceRoots, bool> GetSourceRoots;
         public static Func<GetUntrackedFiles, bool> GetUntrackedFiles;
 
+        private static readonly string s_taskDirectory;
+        private const string GitOperationsAssemblyName = "Microsoft.Build.Tasks.Git.Operations";
+        private static Version s_nullVersion = new Version(0, 0, 0, 0);
+
         static TaskImplementation()
         {
+            s_taskDirectory = Path.GetDirectoryName(typeof(TaskImplementation).Assembly.Location);
 #if NET461
+            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
+
             var assemblyName = typeof(TaskImplementation).Assembly.GetName();
-            assemblyName.Name = "Microsoft.Build.Tasks.Git.Operations";
+            assemblyName.Name = GitOperationsAssemblyName;
             var assembly = Assembly.Load(assemblyName);
 #else
-            var operationsPath = Path.Combine(Path.GetDirectoryName(typeof(TaskImplementation).Assembly.Location), "Microsoft.Build.Tasks.Git.Operations.dll");
+            var operationsPath = Path.Combine(s_taskDirectory, GitOperationsAssemblyName + ".dll");
             var assembly = GitLoaderContext.Instance.LoadFromAssemblyPath(operationsPath);
 #endif
             var type = assembly.GetType("Microsoft.Build.Tasks.Git.RepositoryTasks", throwOnError: true).GetTypeInfo();
@@ -32,5 +39,26 @@ namespace Microsoft.Build.Tasks.Git
             GetSourceRoots = (Func<GetSourceRoots, bool>)type.GetDeclaredMethod(nameof(GetSourceRoots)).CreateDelegate(typeof(Func<GetSourceRoots, bool>));
             GetUntrackedFiles = (Func<GetUntrackedFiles, bool>)type.GetDeclaredMethod(nameof(GetUntrackedFiles)).CreateDelegate(typeof(Func<GetUntrackedFiles, bool>));
         }
+
+#if NET461
+        private static Assembly AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            // only resolve dependencies of netstandard library:
+            if (!StringComparer.OrdinalIgnoreCase.Equals(args.RequestingAssembly.FullName, "netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"))
+            {
+                return null;
+            }
+
+            var referenceName = new AssemblyName(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
+            if (referenceName.Version != s_nullVersion)
+            {
+                return null;
+            }
+
+            // resolve dependencies in the task's directory:
+            var referencePath = Path.Combine(s_taskDirectory, referenceName.Name + ".dll");
+            return File.Exists(referencePath) ? Assembly.Load(referencePath) : null;
+        }
+#endif
     }
 }


### PR DESCRIPTION
AssemblyResolve is needed to load dependencies of netstandard.dll since their version 0.0.0.0 needs to be mapped to the actual assembly version.