### PR TITLE
Revert "Add missing dependency Microsoft.DotNet.PlatformAbstractions.…

### DIFF
--- a/eng/SignToolData.json
+++ b/eng/SignToolData.json
@@ -42,7 +42,6 @@
   "exclude": [
     "git2-b0d9952.dll",
     "LibGit2Sharp.dll",
-    "Microsoft.DotNet.PlatformAbstractions.dll",
     "Microsoft.TeamFoundation.Client.dll",
     "Microsoft.TeamFoundation.Common.dll",
     "Microsoft.TeamFoundation.Core.WebApi.dll",

--- a/src/Microsoft.Build.Tasks.Git.Operations/Microsoft.Build.Tasks.Git.nuspec
+++ b/src/Microsoft.Build.Tasks.Git.Operations/Microsoft.Build.Tasks.Git.nuspec
@@ -24,12 +24,10 @@
     <file src="netcoreapp2.0\publish\runtimes\win-x64\native\*.dll" target="tools\netcoreapp2.0\runtimes\win-x64\native" />
 
     <file src="netcoreapp2.0\publish\LibGit2Sharp.dll" target="tools\netcoreapp2.0" />    
-    <file src="netcoreapp2.0\publish\Microsoft.DotNet.PlatformAbstractions.*" target="tools\netcoreapp2.0" />
     <file src="netcoreapp2.0\publish\Microsoft.Build.Tasks.Git.*" target="tools\netcoreapp2.0" />
     <file src="netcoreapp2.0\publish\**\Microsoft.Build.Tasks.Git.resources.dll" target="tools\netcoreapp2.0" />
 
     <file src="net461\Microsoft.Build.Tasks.Git.*" target="tools\net461" />
-    <file src="net461\Microsoft.DotNet.PlatformAbstractions.*" target="tools\net461" />
     <file src="net461\**\Microsoft.Build.Tasks.Git.resources.dll" target="tools\net461" />
     <file src="net461\LibGit2Sharp.*" target="tools\net461" />
     <file src="net461\lib\**\*.dll" target="tools\net461\lib" />


### PR DESCRIPTION
…dll (#108)"

This reverts commit 1a921c74d729f328bc96746c7e32d8c08b108e05.

Realized that this dependency is only needed on Core and it is available in the SDK, so we don't need to include it in the package.