### PR TITLE
Add SourceControlManagerPublishTranslatedUrls target

### DIFF
--- a/src/SourceLink.Common/build/InitializeSourceControlInformation.targets
+++ b/src/SourceLink.Common/build/InitializeSourceControlInformation.targets
@@ -25,10 +25,11 @@
     Notes: No error is reported if InitializeSourceControlInformation is not defined.
   -->
   <Target Name="_InitializeSourceControlInformationFromSourceControlManager"
-          DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager;_SourceLinkHasSingleProvider;$(SourceControlManagerUrlTranslationTargets)"
+          DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager;_SourceLinkHasSingleProvider;$(SourceControlManagerUrlTranslationTargets);SourceControlManagerPublishTranslatedUrls"
           BeforeTargets="InitializeSourceControlInformation"
-          Condition="'$(EnableSourceControlManagerQueries)' == 'true'">
-    
+          Condition="'$(EnableSourceControlManagerQueries)' == 'true'" />
+
+  <Target Name="SourceControlManagerPublishTranslatedUrls">
     <PropertyGroup>
       <!--
         If the project already sets RepositoryUrl use it. Such URL is considered final and translations are not applied.

--- a/src/SourceLink.Git.IntegrationTests/VstsAndGitHubTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/VstsAndGitHubTests.cs
@@ -26,7 +26,8 @@ namespace Microsoft.SourceLink.IntegrationTests
 ",
                 customTargets: @"
 <Target Name=""TranslateVstsToGitHub""
-        AfterTargets=""$(SourceControlManagerUrlTranslationTargets)"">
+        DependsOnTargets=""$(SourceControlManagerUrlTranslationTargets)""
+        BeforeTargets=""SourceControlManagerPublishTranslatedUrls"">
 
     <PropertyGroup>
       <_Pattern>https://([^.]+)[.]visualstudio.com/([^/]+)/_git/([^/]+)</_Pattern>


### PR DESCRIPTION
Enables define a target that performs custom URL translation after SourceLink packages translated their respective URLs and before the translated URLs are published.