### PR TITLE
update LibGit2Sharp to 0.27.0-preview-0007 for Alpine 3.9

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftBuildTasksCore>15.7.179</MicrosoftBuildTasksCore>
 
     <!-- Libs -->
-    <LibGit2SharpVersion>0.26.0-preview-0070</LibGit2SharpVersion>
+    <LibGit2SharpVersion>0.27.0-preview-0007</LibGit2SharpVersion>
     <MicrosoftTeamFoundationServerExtendedClientVersion>15.112.1</MicrosoftTeamFoundationServerExtendedClientVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <NuGetVersioningVersion>4.9.2</NuGetVersioningVersion>


### PR DESCRIPTION
This version of LibGit2Sharp adds support for Alpine 3.9. You can see it [working for nbgv](https://github.com/AArnott/Nerdbank.GitVersioning/pull/322#issuecomment-485874095). This in combination with #263 to update the RIDs should make Source Link work on Alpine 3.9 as well.