### PR TITLE
Use environment variabels and non-local configurations conditionally

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         [Fact]
         public void MinimalGitData()
         {
-            var environment = new GitEnvironment("/home");
             var repoDir = Temp.CreateDirectory();
 
             var gitDir = repoDir.CreateDirectory(".git");
@@ -42,13 +41,13 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             gitDirSub.CreateDirectory("objects");
             gitDirSub.CreateDirectory("refs");
 
-            var repository = GitRepository.OpenRepository(repoDir.Path, environment);
+            var repository = GitRepository.OpenRepository(repoDir.Path, GitEnvironment.Empty);
 
-            Assert.Equal("http://github.com/test-org/test-repo", GitOperations.GetRepositoryUrl(repository));
+            Assert.Equal("http://github.com/test-org/test-repo", GitOperations.GetRepositoryUrl(repository, remoteName: null));
             Assert.Equal("1111111111111111111111111111111111111111", repository.GetHeadCommitSha());
 
             var warnings = new List<(string, object[])>();
-            var sourceRoots = GitOperations.GetSourceRoots(repository, (message, args) => warnings.Add((message, args)));
+            var sourceRoots = GitOperations.GetSourceRoots(repository, remoteName: null, (message, args) => warnings.Add((message, args)));
             AssertEx.Equal(new[]
             {
                 $@"'{repoDir.Path}{s}' SourceControl='git' RevisionId='1111111111111111111111111111111111111111' ScmRepositoryUrl='http://github.com/test-org/test-repo'",
@@ -65,7 +64,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                 new MockItem(@"sub\ignore_in_submodule_d"),
             };
 
-            var untrackedFiles = GitOperations.GetUntrackedFiles(repository, files, repoDir.Path, path => GitRepository.OpenRepository(path, environment));
+            var untrackedFiles = GitOperations.GetUntrackedFiles(repository, files, repoDir.Path, path => GitRepository.OpenRepository(path, GitEnvironment.Empty));
 
             AssertEx.Equal(new[]
             {

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         }
 
         [Fact]
-        public void OpenReopsitory_VersionNotSupported()
+        public void OpenRepository_VersionNotSupported()
         {
             using var temp = new TempRoot();
 
@@ -190,7 +190,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
 [submodule ""S5""]         # ignore if url unspecified
 	path = s4
 ");
-            var repository = new GitRepository(new GitEnvironment("/home"), GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
 
             var submodules = GitRepository.EnumerateSubmoduleConfig(repository.ReadSubmoduleConfig());
             AssertEx.Equal(new[]
@@ -261,7 +261,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
   path = sub10
   url = http://github.com
 ");
-            var repository = new GitRepository(new GitEnvironment("/home"), GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
 
             var submodules = repository.GetSubmodules();
             AssertEx.Equal(new[]
@@ -348,7 +348,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var gitDir = temp.CreateDirectory();
             gitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master \t\v\r\n");
 
-            var repository = new GitRepository(new GitEnvironment("/home"), GitConfig.Empty, gitDir.Path, commonDir.Path, workingDirectory: null);
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, commonDir.Path, workingDirectory: null);
             Assert.Equal("0000000000000000000000000000000000000000", repository.GetHeadCommitSha());
         }
 
@@ -369,7 +369,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             submoduleRefsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
             submoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
 
-            var repository = new GitRepository(new GitEnvironment("/home"), GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
             Assert.Equal("0000000000000000000000000000000000000000", repository.GetSubmoduleHeadCommitSha(submoduleWorkingDir.Path));
         }
     }

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -332,16 +332,19 @@ namespace Microsoft.Build.Tasks.Git
 
         /// <exception cref="IOException"/>
         /// <exception cref="InvalidDataException"/>
+        /// <exception cref="NotSupportedException"/>
         public ImmutableArray<GitSubmodule> GetSubmodules()
             => _lazySubmodules.Value.Submodules;
 
         /// <exception cref="IOException"/>
         /// <exception cref="InvalidDataException"/>
+        /// <exception cref="NotSupportedException"/>
         public ImmutableArray<string> GetSubmoduleDiagnostics()
             => _lazySubmodules.Value.Diagnostics;
 
         /// <exception cref="IOException"/>
         /// <exception cref="InvalidDataException"/>
+        /// <exception cref="NotSupportedException"/>
         private (ImmutableArray<GitSubmodule> Submodules, ImmutableArray<string> Diagnostics) ReadSubmodules()
         {
             var workingDirectory = GetWorkingDirectory();
@@ -470,8 +473,9 @@ namespace Microsoft.Build.Tasks.Git
 
             while (directory != null)
             {
-                // TODO: stop on device boundary
-                
+                // TODO: https://github.com/dotnet/sourcelink/issues/302
+                // stop on device boundary
+
                 var dotGitPath = Path.Combine(directory, GitDirName);
 
                 if (Directory.Exists(dotGitPath))

--- a/src/Microsoft.Build.Tasks.Git/GitOperations.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitOperations.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Tasks.Git
         private const string RemoteSectionName = "remote";
         private const string UrlSectionName = "url";
 
-        public static string GetRepositoryUrl(GitRepository repository, Action<string, object[]> logWarning = null, string remoteName = null)
+        public static string GetRepositoryUrl(GitRepository repository, string remoteName, Action<string, object[]> logWarning = null)
         {
             string unknownRemoteName = null;
             string remoteUrl = null;
@@ -177,7 +177,7 @@ namespace Microsoft.Build.Tasks.Git
             return Uri.TryCreate(url, UriKind.Absolute, out uri);
         }
 
-        public static ITaskItem[] GetSourceRoots(GitRepository repository, Action<string, object[]> logWarning)
+        public static ITaskItem[] GetSourceRoots(GitRepository repository, string remoteName, Action<string, object[]> logWarning)
         {
             var result = new List<TaskItem>();
             var repoRoot = GetRepositoryRoot(repository);
@@ -186,7 +186,7 @@ namespace Microsoft.Build.Tasks.Git
             if (revisionId != null)
             {
                 // Don't report a warning since it has already been reported by GetRepositoryUrl task.
-                string repositoryUrl = GetRepositoryUrl(repository);
+                string repositoryUrl = GetRepositoryUrl(repository, remoteName, logWarning: null);
 
                 // Item metadata are stored msbuild-escaped. GetMetadata unescapes, SetMetadata stores the value as specified.
                 // Escape msbuild special characters so that URL escapes in the URL are preserved when the URL is read by GetMetadata.

--- a/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Build.Tasks.Git
         {
             RepositoryId = repository.GitDirectory;
             WorkingDirectory = repository.WorkingDirectory;
-            Url = GitOperations.GetRepositoryUrl(repository, Log.LogWarning, RemoteName);
-            Roots = GitOperations.GetSourceRoots(repository, Log.LogWarning);
+            Url = GitOperations.GetRepositoryUrl(repository, RemoteName, Log.LogWarning);
+            Roots = GitOperations.GetSourceRoots(repository, RemoteName, Log.LogWarning);
             RevisionId = repository.GetHeadCommitSha();
         }
     }

--- a/src/Microsoft.Build.Tasks.Git/Resources.resx
+++ b/src/Microsoft.Build.Tasks.Git/Resources.resx
@@ -186,4 +186,10 @@
   <data name="RepositoryDoesNotHaveSpecifiedRemote" xml:space="preserve">
     <value>Repository does not have the specified remote '{0}'; using '{1}' instead.</value>
   </data>
+  <data name="ValueOfIsNotValidConfigurationScope" xml:space="preserve">
+    <value>The value of {0} is not a valid configuration scope: '{1}'.</value>
+  </data>
+  <data name="HomeRelativePathsAreNotAllowed" xml:space="preserve">
+    <value>Home relative paths are not allowed when {0} is '{1}': '{2}'</value>
+  </data>
 </root>

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -2,12 +2,30 @@
 <Project>
   <UsingTask TaskName="Microsoft.Build.Tasks.Git.LocateRepository" AssemblyFile="$(MicrosoftBuildTasksGitAssemblyFile)"/>
   <UsingTask TaskName="Microsoft.Build.Tasks.Git.GetUntrackedFiles" AssemblyFile="$(MicrosoftBuildTasksGitAssemblyFile)"/>
+
+  <PropertyGroup>
+    <!--
+      Sets the scope of git repository configuration. By default (no scope specified) configuration is read from environment variables
+      and system and global user git/ssh configuration files. 
+      
+      If "local" is specified the configuration is only read from the configuration files local to the repository (or work tree).
+      In addition, any use of home relative paths in these configuration files (paths that start with '~/') is disallowed.
+      
+      By default, the scope is restricted to "local" when building in CI (ContinuousIntegrationBuild is true) to avoid introducing 
+      dependencies on CI machine state into the build.
+    -->
+    <GitRepositoryConfigurationScope Condition="'$(GitRepositoryConfigurationScope)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">local</GitRepositoryConfigurationScope>
+  </PropertyGroup>
   
   <Target Name="InitializeSourceControlInformationFromSourceControlManager">
     <!--
       Reports a warning if the given project doesn't belong to a repository under source control.
     -->
-    <Microsoft.Build.Tasks.Git.LocateRepository Path="$(MSBuildProjectDirectory)" >
+    <Microsoft.Build.Tasks.Git.LocateRepository 
+      Path="$(MSBuildProjectDirectory)"
+      RemoteName="$(GitRepositoryRemoteName)"
+      ConfigurationScope="$(GitRepositoryConfigurationScope)" >
+      
       <Output TaskParameter="RepositoryId" PropertyName="_GitRepositoryId" />
       <Output TaskParameter="Url" PropertyName="ScmRepositoryUrl" />
       <Output TaskParameter="Roots" ItemName="SourceRoot" />
@@ -26,7 +44,12 @@
   <Target Name="SetEmbeddedFilesFromSourceControlManagerUntrackedFiles"
           DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
 
-    <Microsoft.Build.Tasks.Git.GetUntrackedFiles RepositoryId="$(_GitRepositoryId)" ProjectDirectory="$(MSBuildProjectDirectory)" Files="@(Compile)">
+    <Microsoft.Build.Tasks.Git.GetUntrackedFiles
+      RepositoryId="$(_GitRepositoryId)"
+      ConfigurationScope="$(GitRepositoryConfigurationScope)"
+      ProjectDirectory="$(MSBuildProjectDirectory)"
+      Files="@(Compile)">
+      
       <Output TaskParameter="UntrackedFiles" ItemName="EmbeddedFiles" />
     </Microsoft.Build.Tasks.Git.GetUntrackedFiles>
   </Target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.cs.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.de.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.es.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.fr.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.it.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ja.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ko.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.pl.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ru.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.tr.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">The format of the file '{0}' is invalid.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HomeRelativePathsAreNotAllowed">
+        <source>Home relative paths are not allowed when {0} is '{1}': '{2}'</source>
+        <target state="new">Home relative paths are not allowed when {0} is '{1}': '{2}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidFormatOfFileAtPath">
         <source>Repository does not have a working directory.</source>
         <target state="new">Repository does not have a working directory.</target>
@@ -110,6 +115,11 @@
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="new">Unsupported repository version {0}. Only versions up to {1} are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValueOfIsNotValidConfigurationScope">
+        <source>The value of {0} is not a valid configuration scope: '{1}'.</source>
+        <target state="new">The value of {0} is not a valid configuration scope: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueOfIsNotValidPath">

--- a/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using LibGit2Sharp;
+using Microsoft.Build.Tasks.Git;
 using TestUtilities;
 using Xunit;
 
@@ -55,9 +56,6 @@ namespace Microsoft.SourceLink.IntegrationTests
         [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void MutlipleProjects()
         {
-            var repoUrl = "http://github.com/test-org/test-repo";
-            var repoName = "test-repo";
-
             var projectName2 = "Project2";
             var projectFileName2 = projectName2 + ".csproj";
 
@@ -71,8 +69,10 @@ namespace Microsoft.SourceLink.IntegrationTests
 
             using var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(
                 RootDir.Path, 
-                new[] { Path.Combine(ProjectName, ProjectFileName), Path.Combine(projectName2, projectFileName2), }, 
-                repoUrl);
+                new[] { Path.Combine(ProjectName, ProjectFileName), Path.Combine(projectName2, projectFileName2) },
+                "http://github.com/test-org/test-repo1");
+
+            repo.Network.Remotes.Add("origin2", "http://github.com/test-org/test-repo2");
 
             var commitSha = repo.Head.Tip.Sha;
 
@@ -81,6 +81,9 @@ namespace Microsoft.SourceLink.IntegrationTests
 <ItemGroup>
   <ProjectReference Include='{project2.Path}'/>
 </ItemGroup>
+<PropertyGroup>
+  <GitRepositoryRemoteName>origin2</GitRepositoryRemoteName>
+</PropertyGroup>
 ",
                 customTargets: "",
                 targets: new[]
@@ -97,13 +100,112 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     SourceRoot,
-                    $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
+                    $"https://raw.githubusercontent.com/test-org/test-repo2/{commitSha}/*",
                     s_relativeSourceLinkJsonPath,
-                    $"http://github.com/test-org/{repoName}",
+                    $"http://github.com/test-org/test-repo2",
                 },
                 // the second project should reuse the repository info cached by the first project:
                 buildVerbosity: "detailed",
                 expectedBuildOutputFilter: line => line.Contains("SourceLink: Reusing cached git repository information."));
+        }
+
+        private void PrepareTestEnvironment()
+        {
+            var homeDir = RootDir.CreateDirectory(".home");
+            var xdgDir = RootDir.CreateDirectory(".xdg");
+
+            EnvironmentVariables.Add("XDG_CONFIG_HOME", xdgDir.Path);
+            EnvironmentVariables.Add("HOME", homeDir.Path);
+
+            if (PathUtils.IsUnixLikePlatform)
+            {
+                EnvironmentVariables.Add("MICROSOFT_SOURCELINK_TEST_ENVIRONMENT_ETC_DIR", homeDir.Path);
+
+                xdgDir.CreateFile("config").WriteAllText(@"[remote ""origin2""]url = http://github.com/test-org/test-repo2");
+            }
+            else
+            {
+                var gitInstallDir = RootDir.CreateDirectory(".gitinstall");
+                var gitExeDir = gitInstallDir.CreateDirectory("bin");
+                gitExeDir.CreateFile("git.exe");
+                var etcDir = gitInstallDir.CreateDirectory("mingw64").CreateDirectory("etc");
+
+                etcDir.CreateFile("gitconfig").WriteAllText(@"[remote ""origin2""]url = http://github.com/test-org/test-repo2");
+
+                var programDataDir = RootDir.CreateDirectory(".programdata");
+
+                EnvironmentVariables.Add("USERPROFILE", homeDir.Path);
+                EnvironmentVariables.Add("PATH", gitExeDir.Path);
+                EnvironmentVariables.Add("PROGRAMDATA", programDataDir.Path);
+            }
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void Environment_Enabled()
+        {
+            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo1");
+            var commitSha = repo.Head.Tip.Sha;
+
+            PrepareTestEnvironment();
+
+            VerifyValues(
+                customProps: $@"
+<PropertyGroup>
+  <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
+  <GitRepositoryRemoteName>origin2</GitRepositoryRemoteName>
+</PropertyGroup>
+",
+                customTargets: "",
+                targets: new[]
+                {
+                    "Build"
+                },
+                expressions: new[]
+                {
+                    "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "$(PrivateRepositoryUrl)",
+                },
+                expectedResults: new[]
+                {
+                    $"https://raw.githubusercontent.com/test-org/test-repo2/{commitSha}/*",
+                    $"http://github.com/test-org/test-repo2",
+                });
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void Environment_Disabled()
+        {
+            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo1");
+            var commitSha = repo.Head.Tip.Sha;
+
+            PrepareTestEnvironment();
+
+            VerifyValues(
+                customProps: $@"
+<PropertyGroup>
+  <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  <GitRepositoryRemoteName>origin2</GitRepositoryRemoteName>
+</PropertyGroup>
+",
+                customTargets: "",
+                targets: new[]
+                {
+                    "Build"
+                },
+                expressions: new[]
+                {
+                    "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "$(PrivateRepositoryUrl)",
+                },
+                expectedResults: new[]
+                {
+                    $"https://raw.githubusercontent.com/test-org/test-repo1/{commitSha}/*",
+                    $"http://github.com/test-org/test-repo1",
+                },
+                expectedWarnings: new[]
+                {
+                    string.Format(Resources.RepositoryDoesNotHaveSpecifiedRemote, "origin2", "origin")
+                });
         }
 
         [ConditionalFact(typeof(DotNetSdkAvailable))]

--- a/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             {
                 EnvironmentVariables.Add("MICROSOFT_SOURCELINK_TEST_ENVIRONMENT_ETC_DIR", homeDir.Path);
 
-                xdgDir.CreateFile("config").WriteAllText(@"[remote ""origin2""]url = http://github.com/test-org/test-repo2");
+                xdgDir.CreateDirectory("git").CreateFile("config").WriteAllText(@"[remote ""origin2""]url = http://github.com/test-org/test-repo2");
             }
             else
             {

--- a/src/TestUtilities/DotNetSdk/DotNetSdkTestBase.cs
+++ b/src/TestUtilities/DotNetSdk/DotNetSdkTestBase.cs
@@ -68,7 +68,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         protected readonly string Configuration;
         protected readonly string TargetFramework;
         protected readonly string DotNetPath;
-        protected readonly IReadOnlyDictionary<string, string> EnvironmentVariables;
+        protected readonly Dictionary<string, string> EnvironmentVariables;
 
         protected static readonly string s_relativeSourceLinkJsonPath = Path.Combine("obj", "Debug", "netstandard2.0", "test.sourcelink.json");
         protected static readonly string s_relativeOutputFilePath = Path.Combine("obj", "Debug", "netstandard2.0", "test.dll");


### PR DESCRIPTION
Add property `GitRepositoryConfigurationScope` that specifies whether configuration is read from environment variables and system and global user git/ssh configuration files, or just from the repository local config file. 

Set `GitRepositoryConfigurationScope` to `local` on CI server to avoid build non-determinism.
In local builds read all configuration files available on the machine to allow for developer-customized repo configurations.