### PR TITLE
Check if file needs to be rebuilt before writing it

### DIFF
--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -141,35 +141,29 @@ namespace Microsoft.SourceLink.Common.UnitTests
         [Fact]
         public void DoesNotRewriteContentIfFileContentIsSame()
         {
-            var tempFile = Path.GetTempFileName();
-            try
+            using var temp = new TempRoot();
+            var tempFile = temp.CreateFile();
+            
+            var engine = new MockEngine();
+            var task = new GenerateSourceLinkFile()
             {
-                var engine = new MockEngine();
-                var task = new GenerateSourceLinkFile()
+                BuildEngine = engine,
+                SourceRoots = new[]
                 {
-                    BuildEngine = engine,
-                    SourceRoots = new[]
-                    {
-                        new MockItem(@"/_""_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
-                    },
-                    OutputFile = tempFile
-                };
+                    new MockItem(@"/_""_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
+                },
+                OutputFile = tempFile.Path
+            };
 
-                var result = task.Execute();
+            var result = task.Execute();
 
-                var beforeWriteTime = File.GetLastWriteTime(tempFile);
+            var beforeWriteTime = File.GetLastWriteTime(tempFile.Path);
 
-                result = task.Execute();
+            result = task.Execute();
 
-                var afterWriteTime = File.GetLastWriteTime(tempFile);
+            var afterWriteTime = File.GetLastWriteTime(tempFile.Path);
 
-                Assert.Equal(beforeWriteTime, afterWriteTime);
-            }
-            finally
-            {
-                File.Delete(tempFile);
-            }
+            Assert.Equal(beforeWriteTime, afterWriteTime);
         }
-        
     }
 }

--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -137,5 +137,39 @@ namespace Microsoft.SourceLink.Common.UnitTests
 
             Assert.Null(content);
         }
+
+        [Fact]
+        public void DoesNotRewriteContentIfFileContentIsSame()
+        {
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                var engine = new MockEngine();
+                var task = new GenerateSourceLinkFile()
+                {
+                    BuildEngine = engine,
+                    SourceRoots = new[]
+                    {
+                        new MockItem(@"/_""_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
+                    },
+                    OutputFile = tempFile
+                };
+
+                var result = task.Execute();
+
+                var beforeWriteTime = File.GetLastWriteTime(tempFile);
+
+                result = task.Execute();
+
+                var afterWriteTime = File.GetLastWriteTime(tempFile);
+
+                Assert.Equal(beforeWriteTime, afterWriteTime);
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+        }
+        
     }
 }

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -112,6 +112,16 @@ namespace Microsoft.SourceLink.Common
         {
             try
             {
+                if (File.Exists(OutputFile))
+                {
+                    var originalContent = File.ReadAllText(OutputFile);
+                    if (originalContent == content)
+                    {
+                        // Don't rewrite the file if the contents are the same
+                        return;
+                    }
+                }
+
                 File.WriteAllText(OutputFile, content);
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes https://github.com/dotnet/sourcelink/issues/332

If you'd like, I can make it so the test checks hashs instead of write time.

Also let me know if the target branch is correct.