### PR TITLE
Implement packed-refs

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System;
+using System.IO;
+using System.Linq;
+using TestUtilities;
+using Xunit;
+
+namespace Microsoft.Build.Tasks.Git.UnitTests
+{
+    public class GitReferenceResolverTests
+    {
+        [Fact]
+        public void ResolveReference()
+        {
+            using var temp = new TempRoot();
+
+            var gitDir = temp.CreateDirectory();
+
+            var commonDir = temp.CreateDirectory();
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+
+            refsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
+            refsHeadsDir.CreateFile("br1").WriteAllText("ref: refs/heads/br2");
+            refsHeadsDir.CreateFile("br2").WriteAllText("ref: refs/heads/master");
+
+            var resolver = new GitReferenceResolver(gitDir.Path, commonDir.Path);
+
+            Assert.Equal("0123456789ABCDEFabcdef000000000000000000", resolver.ResolveReference("0123456789ABCDEFabcdef000000000000000000"));
+
+            Assert.Equal("0000000000000000000000000000000000000000", resolver.ResolveReference("ref: refs/heads/master"));
+            Assert.Equal("0000000000000000000000000000000000000000", resolver.ResolveReference("ref: refs/heads/br1"));
+            Assert.Equal("0000000000000000000000000000000000000000", resolver.ResolveReference("ref: refs/heads/br2"));
+
+            // branch without commits (emtpy repository) will have not file in refs/heads:
+            Assert.Null(resolver.ResolveReference("ref: refs/heads/none"));
+
+            Assert.Null(resolver.ResolveReference("ref: refs/heads/rec1   "));
+            Assert.Null(resolver.ResolveReference("ref: refs/heads/none" + string.Join("/", Path.GetInvalidPathChars())));
+        }
+
+        [Fact]
+        public void ResolveReference_Errors()
+        {
+            using var temp = new TempRoot();
+
+            var gitDir = temp.CreateDirectory();
+
+            var commonDir = temp.CreateDirectory();
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+
+            refsHeadsDir.CreateFile("rec1").WriteAllText("ref: refs/heads/rec2");
+            refsHeadsDir.CreateFile("rec2").WriteAllText("ref: refs/heads/rec1");
+
+            var resolver = new GitReferenceResolver(gitDir.Path, commonDir.Path);
+
+            Assert.Throws<InvalidDataException>(() => resolver.ResolveReference("ref: refs/heads/rec1"));
+            Assert.Throws<InvalidDataException>(() => resolver.ResolveReference("ref: xyz/heads/rec1"));
+            Assert.Throws<InvalidDataException>(() => resolver.ResolveReference("ref:refs/heads/rec1"));
+            Assert.Throws<InvalidDataException>(() => resolver.ResolveReference("refs/heads/rec1"));
+            Assert.Throws<InvalidDataException>(() => resolver.ResolveReference(new string('0', 39)));
+            Assert.Throws<InvalidDataException>(() => resolver.ResolveReference(new string('0', 41)));
+        }
+
+        [Fact]
+        public void ResolveReference_Packed()
+        {
+            using var temp = new TempRoot();
+
+            var gitDir = temp.CreateDirectory();
+
+            gitDir.CreateFile("packed-refs").WriteAllText(
+@"# pack-refs with: peeled fully-peeled sorted
+1111111111111111111111111111111111111111 refs/heads/master
+2222222222222222222222222222222222222222 refs/heads/br2
+");
+            var commonDir = temp.CreateDirectory();
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+
+            refsHeadsDir.CreateFile("br1").WriteAllText("ref: refs/heads/br2");
+
+            var resolver = new GitReferenceResolver(gitDir.Path, commonDir.Path);
+
+            Assert.Equal("1111111111111111111111111111111111111111", resolver.ResolveReference("ref: refs/heads/master"));
+            Assert.Equal("2222222222222222222222222222222222222222", resolver.ResolveReference("ref: refs/heads/br1"));
+            Assert.Equal("2222222222222222222222222222222222222222", resolver.ResolveReference("ref: refs/heads/br2"));
+        }
+
+        [Fact]
+        public void ReadPackedReferences()
+        {
+            var packedRefs =
+@"# pack-refs with:
+1111111111111111111111111111111111111111 refs/heads/master
+2222222222222222222222222222222222222222 refs/heads/br
+^3333333333333333333333333333333333333333
+4444444444444444444444444444444444444444 x
+5555555555555555555555555555555555555555 y 
+6666666666666666666666666666666666666666 y z
+7777777777777777777777777777777777777777 refs/heads/br
+";
+
+            var actual = GitReferenceResolver.ReadPackedReferences(new StringReader(packedRefs), "<path>");
+
+            AssertEx.SetEqual(new[]
+            {
+                "refs/heads/br:2222222222222222222222222222222222222222",
+                "refs/heads/master:1111111111111111111111111111111111111111"
+            }, actual.Select(e => $"{e.Key}:{e.Value}"));
+        }
+
+        [Theory]
+        [InlineData("# pack-refs with:")]
+        [InlineData("# pack-refs with:xyz")]
+        [InlineData("# pack-refs with:xyz\n")]
+        public void ReadPackedReferences_Empty(string content)
+        {
+            Assert.Empty(GitReferenceResolver.ReadPackedReferences(new StringReader(content), "<path>"));
+        }
+
+        [Theory]
+        [InlineData("")]                                                               // missing header
+        [InlineData("# pack-refs with")]                                               // invalid header prefix
+        [InlineData("# pack-refs with:xyz\n1")]                                        // bad object id
+        [InlineData("# pack-refs with:xyz\n1111111111111111111111111111111111111111")] // no reference name
+        [InlineData("# pack-refs with:xyz\n^1111111111111111111111111111111111111111")]      // tag dereference without previous ref
+        [InlineData("# pack-refs with:xyz\n1111111111111111111111111111111111111111 x\n^1")] // bad object id
+        [InlineData("# pack-refs with:xyz\n^1111111111111111111111111111111111111111\n^2222222222222222222222222222222222222222")] // tag dereference without previous ref
+        public void ReadPackedReferences_Errors(string content)
+        {
+            Assert.Throws<InvalidDataException>(() => GitReferenceResolver.ReadPackedReferences(new StringReader(content), "<path>"));
+        }
+    }
+}

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -299,50 +299,6 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         }
 
         [Fact]
-        public void ResolveReference()
-        {
-            using var temp = new TempRoot();
-
-            var commonDir = temp.CreateDirectory();
-            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
-
-            refsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
-            refsHeadsDir.CreateFile("br1").WriteAllText("ref: refs/heads/br2");
-            refsHeadsDir.CreateFile("br2").WriteAllText("ref: refs/heads/master");
-
-            Assert.Equal("0123456789ABCDEFabcdef000000000000000000", GitRepository.ResolveReference("0123456789ABCDEFabcdef000000000000000000", commonDir.Path));
-
-            Assert.Equal("0000000000000000000000000000000000000000", GitRepository.ResolveReference("ref: refs/heads/master", commonDir.Path));
-            Assert.Equal("0000000000000000000000000000000000000000", GitRepository.ResolveReference("ref: refs/heads/br1", commonDir.Path));
-            Assert.Equal("0000000000000000000000000000000000000000", GitRepository.ResolveReference("ref: refs/heads/br2", commonDir.Path));
-
-            // branch without commits (emtpy repository) will have not file in refs/heads:
-            Assert.Null(GitRepository.ResolveReference("ref: refs/heads/none", commonDir.Path));
-
-            Assert.Null(GitRepository.ResolveReference("ref: refs/heads/rec1   ", commonDir.Path));
-            Assert.Null(GitRepository.ResolveReference("ref: refs/heads/none" + string.Join("/", Path.GetInvalidPathChars()), commonDir.Path));
-        }
-
-        [Fact]
-        public void ResolveReference_Errors()
-        {
-            using var temp = new TempRoot();
-
-            var commonDir = temp.CreateDirectory();
-            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
-
-            refsHeadsDir.CreateFile("rec1").WriteAllText("ref: refs/heads/rec2");
-            refsHeadsDir.CreateFile("rec2").WriteAllText("ref: refs/heads/rec1");
-
-            Assert.Throws<InvalidDataException>(() => GitRepository.ResolveReference("ref: refs/heads/rec1", commonDir.Path));
-            Assert.Throws<InvalidDataException>(() => GitRepository.ResolveReference("ref: xyz/heads/rec1", commonDir.Path));
-            Assert.Throws<InvalidDataException>(() => GitRepository.ResolveReference("ref:refs/heads/rec1", commonDir.Path));
-            Assert.Throws<InvalidDataException>(() => GitRepository.ResolveReference("refs/heads/rec1", commonDir.Path));
-            Assert.Throws<InvalidDataException>(() => GitRepository.ResolveReference(new string('0', 39), commonDir.Path));
-            Assert.Throws<InvalidDataException>(() => GitRepository.ResolveReference(new string('0', 41), commonDir.Path));
-        }
-
-        [Fact]
         public void GetHeadCommitSha()
         {
             using var temp = new TempRoot();
@@ -376,7 +332,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             submoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
 
             var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
-            Assert.Equal("0000000000000000000000000000000000000000", repository.GetSubmoduleHeadCommitSha(submoduleWorkingDir.Path));
+            Assert.Equal("0000000000000000000000000000000000000000", repository.ReadSubmoduleHeadCommitSha(submoduleWorkingDir.Path));
         }
     }
 }

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/CharUtils.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/CharUtils.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Build.Tasks.Git
     internal static class CharUtils
     {
         public static char[] AsciiWhitespace = { ' ', '\t', '\n', '\f', '\r', '\v' };
+        public static char[] WhitespaceSeparators = { ' ', '\t', '\f', '\v' };
 
         public static bool IsHexadecimalDigit(char c)
             => c >= '0' && c <= '9' || c >= 'A' && c <= 'F' || c >= 'a' && c <= 'f';

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Build.Tasks.Git
+{
+    internal sealed class GitReferenceResolver
+    {
+        // See https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-HEAD
+
+        private const string PackedRefsFileName = "packed-refs";
+        private const string RefsPrefix = "refs/";
+
+        private readonly string _commonDirectory;
+        private readonly string _gitDirectory;
+
+        // maps refs/heads references to the correspondign object ids:
+        private readonly Lazy<ImmutableDictionary<string, string>> _lazyPackedReferences;
+
+        public GitReferenceResolver(string gitDirectory, string commonDirectory)
+        {
+            Debug.Assert(PathUtils.IsNormalized(gitDirectory));
+            Debug.Assert(PathUtils.IsNormalized(commonDirectory));
+
+            _gitDirectory = gitDirectory;
+            _commonDirectory = commonDirectory;
+            _lazyPackedReferences = new Lazy<ImmutableDictionary<string, string>>(() => ReadPackedReferences(_gitDirectory));
+        }
+
+        private static ImmutableDictionary<string, string> ReadPackedReferences(string gitDirectory)
+        {
+            // https://git-scm.com/docs/git-pack-refs
+
+            var packedRefsPath = Path.Combine(gitDirectory, PackedRefsFileName);
+            if (!File.Exists(packedRefsPath))
+            {
+                return ImmutableDictionary<string, string>.Empty;
+            }
+
+            TextReader reader;
+            try
+            {
+                reader = File.OpenText(packedRefsPath);
+            }
+            catch
+            {
+                return ImmutableDictionary<string, string>.Empty;
+            }
+
+            using (reader)
+            {
+                return ReadPackedReferences(reader, packedRefsPath);
+            }
+        }
+
+        // internal for testing
+        internal static ImmutableDictionary<string, string> ReadPackedReferences(TextReader reader, string path)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+
+            // header: 
+            // "# pack-refs with:" [options]
+
+            var header = reader.ReadLine();
+            if (header == null || !header.StartsWith("# pack-refs with:"))
+            {
+                throw new InvalidDataException($"Expected header not found at the beginning of file '{path}'.");
+            }
+
+            string previousObjectId = null;
+            while (true)
+            {
+                var line = reader.ReadLine();
+                if (line == null)
+                {
+                    return builder.ToImmutable();
+                }
+
+                Exception invalidData() => new InvalidDataException($"Invalid packed references specification in '{path}': '{line}'");
+
+                // When the line starts with ^ it specifies an id of the object
+                // pointed to by a tag identified on the previous line
+                if (line.Length > 0 && line[0] == '^')
+                {
+                    if (previousObjectId == null)
+                    {
+                        throw invalidData();
+                    }
+
+                    var dereferencedTagObjectId = line.Substring(1);
+                    if (!IsObjectId(dereferencedTagObjectId))
+                    {
+                        throw invalidData();
+                    }
+
+                    // currently we don't need the dereferenced tag object id for anything, 
+                    // so we just skip the line
+                    continue;
+                }
+
+                int separator = line.IndexOfAny(CharUtils.WhitespaceSeparators);
+                if (separator == -1)
+                {
+                    throw invalidData();
+                }
+
+                var objectId = line.Substring(0, separator);
+                if (!IsObjectId(objectId))
+                {
+                    throw invalidData();
+                }
+
+                int nextSeparator = line.IndexOfAny(CharUtils.WhitespaceSeparators, separator + 1);
+                var reference = (nextSeparator >= 0) ? line.Substring(separator + 1, nextSeparator - separator - 1) : line.Substring(separator + 1);
+
+                if (reference.Length == 0)
+                {
+                    throw invalidData();
+                }
+
+                previousObjectId = objectId;
+
+                // if any text (even whitespace) follows next whitespace separator the line is ignored
+                if (nextSeparator >= 0)
+                {
+                    continue;
+                }
+
+                // we are only interested in references
+                if (!reference.StartsWith(RefsPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // Its not clear how git handles duplicates. Take the first one.
+                if (!builder.ContainsKey(reference))
+                {
+                    builder.Add(reference, objectId);
+                }
+            }
+        }
+
+        /// <exception cref="IOException"/>
+        /// <exception cref="InvalidDataException"/>
+        public string ResolveHeadReference()
+            => ResolveReference(ReadReferenceFromFile(Path.Combine(_gitDirectory, GitRepository.GitHeadFileName)));
+
+        public string ResolveReference(string reference)
+        {
+            HashSet<string> lazyVisitedReferences = null;
+            return ResolveReference(reference, ref lazyVisitedReferences);
+        }
+
+        /// <exception cref="IOException"/>
+        /// <exception cref="InvalidDataException"/>
+        private string ResolveReference(string reference, ref HashSet<string> lazyVisitedReferences)
+        {
+            // See https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-HEAD
+
+            const string refPrefix = "ref: ";
+            if (reference.StartsWith(refPrefix + RefsPrefix, StringComparison.Ordinal))
+            {
+                var symRef = reference.Substring(refPrefix.Length);
+
+                if (lazyVisitedReferences != null && !lazyVisitedReferences.Add(symRef))
+                {
+                    // infinite recursion
+                    throw new InvalidDataException(string.Format(Resources.RecursionDetectedWhileResolvingReference, reference));
+                }
+
+                string path;
+                try
+                {
+                    path = Path.Combine(_commonDirectory, symRef);
+                }
+                catch
+                {
+                    return null;
+                }
+
+                if (!File.Exists(path))
+                {
+                    return ResolvePackedReference(symRef);
+                }
+
+                string content;
+                try
+                {
+                    content = ReadReferenceFromFile(path);
+                }
+                catch (Exception e) when (e is ArgumentException || e is FileNotFoundException || e is DirectoryNotFoundException)
+                {
+                    // invalid path or file doesn't exist:
+                    return ResolvePackedReference(symRef);
+                }
+
+                if (IsObjectId(content))
+                {
+                    return content;
+                }
+
+                lazyVisitedReferences ??= new HashSet<string>();
+
+                return ResolveReference(content, ref lazyVisitedReferences);
+            }
+
+            if (IsObjectId(reference))
+            {
+                return reference;
+            }
+
+            throw new InvalidDataException(string.Format(Resources.InvalidReference, reference));
+        }
+
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="IOException"/>
+        internal static string ReadReferenceFromFile(string path)
+        {
+            try
+            {
+                return File.ReadAllText(path).TrimEnd(CharUtils.AsciiWhitespace);
+            }
+            catch (Exception e) when (!(e is ArgumentException) && !(e is IOException))
+            {
+                throw new IOException(e.Message, e);
+            }
+        }
+
+        private string ResolvePackedReference(string reference)
+            => _lazyPackedReferences.Value.TryGetValue(reference, out var objectId) ? objectId : null;
+
+        private static bool IsObjectId(string reference)
+            => reference.Length == 40 && reference.All(CharUtils.IsHexadecimalDigit);
+    }
+}


### PR DESCRIPTION
Implements support for `packed-refs` file.

Fixes https://github.com/dotnet/sourcelink/issues/343.