### PR TITLE
Trim trailing whitespace when reading commondir

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var worktreeGitSubDir = worktreeGitDir.CreateDirectory("B");
             var worktreeDir = temp.CreateDirectory();
             var worktreeSubDir = worktreeDir.CreateDirectory("C");
-            var worktreeGitFile = worktreeDir.CreateFile(".git").WriteAllText("gitdir: " + worktreeGitDir);
+            var worktreeGitFile = worktreeDir.CreateFile(".git").WriteAllText("gitdir: " + worktreeGitDir + " \r\n\t\v");
 
             worktreeGitDir.CreateFile("HEAD");
-            worktreeGitDir.CreateFile("commondir").WriteAllText(mainGitDir.Path);
-            worktreeGitDir.CreateFile("gitdir").WriteAllText(worktreeGitFile.Path);
+            worktreeGitDir.CreateFile("commondir").WriteAllText(mainGitDir.Path + " \r\n\t\v");
+            worktreeGitDir.CreateFile("gitdir").WriteAllText(worktreeGitFile.Path + " \r\n\t\v");
 
             // start under main repository directory:
             Assert.True(GitRepository.LocateRepository(

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -473,8 +473,7 @@ namespace Microsoft.Build.Tasks.Git
             {
                 try
                 {
-                    // note: git does not trim whitespace
-                    commonDirectory = Path.Combine(directory, File.ReadAllText(commonLinkPath));
+                    commonDirectory = Path.Combine(directory, File.ReadAllText(commonLinkPath).TrimEnd(CharUtils.AsciiWhitespace));
                 }
                 catch
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sourcelink/issues/347.

