### PR TITLE
Source build fixes for target framework and project exclusions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <PreReleaseVersionLabel>beta2</PreReleaseVersionLabel>
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <!-- Opt-in repo features -->
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <XUnitVersion>2.4.1</XUnitVersion>
     <!-- 

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/Microsoft.Build.Tasks.Git.UnitTests.csproj
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/Microsoft.Build.Tasks.Git.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Build.Tasks.Git\Microsoft.Build.Tasks.Git.csproj" />

--- a/src/Microsoft.Build.Tasks.Git/Microsoft.Build.Tasks.Git.csproj
+++ b/src/Microsoft.Build.Tasks.Git/Microsoft.Build.Tasks.Git.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->

--- a/src/SourceLink.Bitbucket.Git.UnitTests/Microsoft.SourceLink.Bitbucket.Git.UnitTests.csproj
+++ b/src/SourceLink.Bitbucket.Git.UnitTests/Microsoft.SourceLink.Bitbucket.Git.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.Bitbucket.Git\Microsoft.SourceLink.Bitbucket.Git.csproj" />

--- a/src/SourceLink.Bitbucket.Git/Microsoft.SourceLink.Bitbucket.Git.SourceBuild.nuspec
+++ b/src/SourceLink.Bitbucket.Git/Microsoft.SourceLink.Bitbucket.Git.SourceBuild.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Git" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildCrossTargeting\*.*" target="buildCrossTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.Bitbucket.Git/Microsoft.SourceLink.Bitbucket.Git.csproj
+++ b/src/SourceLink.Bitbucket.Git/Microsoft.SourceLink.Bitbucket.Git.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
 
     <PackageDescription>Generates source link for Bitbucket repositories.</PackageDescription>

--- a/src/SourceLink.Common.UnitTests/Microsoft.SourceLink.Common.UnitTests.csproj
+++ b/src/SourceLink.Common.UnitTests/Microsoft.SourceLink.Common.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />

--- a/src/SourceLink.Common/Microsoft.SourceLink.Common.SourceBuild.nuspec
+++ b/src/SourceLink.Common/Microsoft.SourceLink.Common.SourceBuild.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.Common.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildCrossTargeting\*.*" target="buildCrossTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.Common/Microsoft.SourceLink.Common.csproj
+++ b/src/SourceLink.Common/Microsoft.SourceLink.Common.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
 
     <PackageDescription>MSBuild tasks providing source control information.</PackageDescription>

--- a/src/SourceLink.Git.IntegrationTests/Microsoft.SourceLink.Git.IntegrationTests.csproj
+++ b/src/SourceLink.Git.IntegrationTests/Microsoft.SourceLink.Git.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />

--- a/src/SourceLink.GitHub.UnitTests/Microsoft.SourceLink.GitHub.UnitTests.csproj
+++ b/src/SourceLink.GitHub.UnitTests/Microsoft.SourceLink.GitHub.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.GitHub\Microsoft.SourceLink.GitHub.csproj" />

--- a/src/SourceLink.GitHub/Microsoft.SourceLink.GitHub.SourceBuild.nuspec
+++ b/src/SourceLink.GitHub/Microsoft.SourceLink.GitHub.SourceBuild.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Git" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildCrossTargeting\*.*" target="buildCrossTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.GitHub/Microsoft.SourceLink.GitHub.csproj
+++ b/src/SourceLink.GitHub/Microsoft.SourceLink.GitHub.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
 
     <PackageDescription>Generates source link for GitHub repositories.</PackageDescription>

--- a/src/SourceLink.GitLab.UnitTests/Microsoft.SourceLink.GitLab.UnitTests.csproj
+++ b/src/SourceLink.GitLab.UnitTests/Microsoft.SourceLink.GitLab.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.GitLab\Microsoft.SourceLink.GitLab.csproj" />

--- a/src/SourceLink.GitLab/Microsoft.SourceLink.GitLab.SourceBuild.nuspec
+++ b/src/SourceLink.GitLab/Microsoft.SourceLink.GitLab.SourceBuild.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Git" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildCrossTargeting\*.*" target="buildCrossTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.GitLab/Microsoft.SourceLink.GitLab.csproj
+++ b/src/SourceLink.GitLab/Microsoft.SourceLink.GitLab.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
 
     <PackageDescription>Generates source link for GitLab repositories.</PackageDescription>

--- a/src/SourceLink.Tfs.Git.UnitTests/Microsoft.SourceLink.Tfs.Git.UnitTests.csproj
+++ b/src/SourceLink.Tfs.Git.UnitTests/Microsoft.SourceLink.Tfs.Git.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.Tfs.Git\Microsoft.SourceLink.Tfs.Git.csproj" />

--- a/src/SourceLink.Tfs.Git/Microsoft.SourceLink.Tfs.Git.SourceBuild.nuspec
+++ b/src/SourceLink.Tfs.Git/Microsoft.SourceLink.Tfs.Git.SourceBuild.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Git" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildCrossTargeting\*.*" target="buildCrossTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.Tfs.Git/Microsoft.SourceLink.Tfs.Git.csproj
+++ b/src/SourceLink.Tfs.Git/Microsoft.SourceLink.Tfs.Git.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
 
     <PackageDescription>Generates source link for VSTS Git repositories.</PackageDescription>

--- a/src/SourceLink.Vsts.Git.UnitTests/Microsoft.SourceLink.Vsts.Git.UnitTests.csproj
+++ b/src/SourceLink.Vsts.Git.UnitTests/Microsoft.SourceLink.Vsts.Git.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.Vsts.Git\Microsoft.SourceLink.Vsts.Git.csproj" />

--- a/src/SourceLink.Vsts.Git/Microsoft.SourceLink.Vsts.Git.SourceBuild.nuspec
+++ b/src/SourceLink.Vsts.Git/Microsoft.SourceLink.Vsts.Git.SourceBuild.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Git" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildCrossTargeting\*.*" target="buildCrossTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.Vsts.Git/Microsoft.SourceLink.Vsts.Git.csproj
+++ b/src/SourceLink.Vsts.Git/Microsoft.SourceLink.Vsts.Git.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
 
     <PackageDescription>Generates source link for VSTS Git repositories.</PackageDescription>

--- a/src/SourceLink.Vsts.Tfvc/Microsoft.SourceLink.Vsts.Tfvc.SourceBuild.nuspec
+++ b/src/SourceLink.Vsts.Tfvc/Microsoft.SourceLink.Vsts.Tfvc.SourceBuild.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Tfvc" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netcoreapp2.0\publish\**\Microsoft.SourceLink.*" target="tools\netcoreapp2.0" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+  </files>
+</package>

--- a/src/SourceLink.Vsts.Tfvc/Microsoft.SourceLink.Vsts.Tfvc.csproj
+++ b/src/SourceLink.Vsts.Tfvc/Microsoft.SourceLink.Vsts.Tfvc.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.0</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildFromSource)' == 'true'">$(MSBuildProjectName).SourceBuild.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     
     <PackageDescription>Generates source link for VSTS TFVC repositories.</PackageDescription>


### PR DESCRIPTION
Two changes for source-build:
- Exclude test projects from source-build.
- Build only for .NET Core in source-build.  This allows us to get rid of the .NET Framework reference assembly prebuilt package.

cc @NikolaMilosavljevic @adaggarwal