### PR TITLE
Update BitBucket Cloud to use API 2.0 URLs.

### DIFF
--- a/src/SourceLink.Bitbucket.Git.UnitTests/GetSourceLinkUrlTests.cs
+++ b/src/SourceLink.Bitbucket.Git.UnitTests/GetSourceLinkUrlTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SourceLink.Bitbucket.Git.UnitTests
     public class GetSourceLinkUrlTests
     {
         private const string ExpectedUrlForCloudEdition =
-            "https://domain.com/x/y/a/b/raw/0123456789abcdefABCDEF000000000000000000/*";
+            "https://api.domain.com/x/y/2.0/repositories/a/b/src/0123456789abcdefABCDEF000000000000000000/*";
         private const string ExpectedUrlForEnterpriseEditionOldVersion = "https://bitbucket.domain.com/projects/a/repos/b/browse/*?at=0123456789abcdefABCDEF000000000000000000&raw";
         private const string ExpectedUrlForEnterpriseEditionNewVersion = "https://bitbucket.domain.com/projects/a/repos/b/raw/*?at=0123456789abcdefABCDEF000000000000000000";
 

--- a/src/SourceLink.Bitbucket.Git/GetSourceLinkUrl.cs
+++ b/src/SourceLink.Bitbucket.Git/GetSourceLinkUrl.cs
@@ -71,7 +71,7 @@ namespace Microsoft.SourceLink.Bitbucket.Git
 
         private static string BuildSourceLinkUrlForCloudEdition(Uri contentUri, string relativeUrl, string revisionId)
         {
-            // change bitbuket.org to api.bitbucket.org
+            // change bitbucket.org to api.bitbucket.org
             UriBuilder apiUriBuilder = new UriBuilder(contentUri);
             apiUriBuilder.Host = $"api.{apiUriBuilder.Host}";
 

--- a/src/SourceLink.Bitbucket.Git/GetSourceLinkUrl.cs
+++ b/src/SourceLink.Bitbucket.Git/GetSourceLinkUrl.cs
@@ -71,8 +71,13 @@ namespace Microsoft.SourceLink.Bitbucket.Git
 
         private static string BuildSourceLinkUrlForCloudEdition(Uri contentUri, string relativeUrl, string revisionId)
         {
-            return UriUtilities.Combine(UriUtilities.Combine(contentUri.ToString(), relativeUrl),
-                "raw/" + revisionId + "/*");
+            // change bitbuket.org to api.bitbucket.org
+            UriBuilder apiUriBuilder = new UriBuilder(contentUri);
+            apiUriBuilder.Host = $"api.{apiUriBuilder.Host}";
+
+            string relativeApiUrl = UriUtilities.Combine(UriUtilities.Combine("2.0/repositories", relativeUrl), $"src/{revisionId}/*");
+
+            return UriUtilities.Combine(apiUriBuilder.Uri.ToString(), relativeApiUrl);
         }
 
         private static string GetRelativeUrlForBitbucketEnterprise(string projectName, string repositoryName, string commitId, Version bitbucketVersion)

--- a/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
@@ -44,14 +44,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     ProjectSourceRoot,
-                    $"https://bitbucket.org/test-org/{repoName}/raw/{commitSha}/*",
+                    $"https://api.bitbucket.org/2.0/repositories/test-org/{repoName}/src/{commitSha}/*",
                     s_relativeSourceLinkJsonPath,
                     $"https://bitbucket.org/test-org/{repoName}",
                     $"https://bitbucket.org/test-org/{repoName}"
                 });
 
             AssertEx.AreEqual(
-                $@"{{""documents"":{{""{ProjectSourceRoot.Replace(@"\", @"\\")}*"":""https://bitbucket.org/test-org/{repoName}/raw/{commitSha}/*""}}}}",
+                $@"{{""documents"":{{""{ProjectSourceRoot.Replace(@"\", @"\\")}*"":""https://api.bitbucket.org/2.0/repositories/test-org/{repoName}/src/{commitSha}/*""}}}}",
                 File.ReadAllText(Path.Combine(ProjectDir.Path, s_relativeSourceLinkJsonPath)));
 
             TestUtilities.ValidateAssemblyInformationalVersion(
@@ -274,14 +274,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     ProjectSourceRoot,
-                    $"https://噸.com/test-org/{repoName}/raw/{commitSha}/*",
+                    $"https://api.噸.com/2.0/repositories/test-org/{repoName}/src/{commitSha}/*",
                     s_relativeSourceLinkJsonPath,
                     $"https://噸.com/test-org/{repoName}",
                     $"https://噸.com/test-org/{repoName}"
                 });
 
             AssertEx.AreEqual(
-                $@"{{""documents"":{{""{ProjectSourceRoot.Replace(@"\", @"\\")}*"":""https://噸.com/test-org/{repoName}/raw/{commitSha}/*""}}}}",
+                $@"{{""documents"":{{""{ProjectSourceRoot.Replace(@"\", @"\\")}*"":""https://api.噸.com/2.0/repositories/test-org/{repoName}/src/{commitSha}/*""}}}}",
                 File.ReadAllText(Path.Combine(ProjectDir.Path, s_relativeSourceLinkJsonPath)));
 
             TestUtilities.ValidateAssemblyInformationalVersion(


### PR DESCRIPTION
BitBucket Cloud 2FA does not work in VS for a few reasons. The first is
that Basic HTTP Auth is completely disabled when 2FA is enabled on the
account. Falling back to OAuth authentication works, but only for the
official REST API. Currently, BitBucket Source Link produces 'web
browser' URL's, using the
https://bitbucket.org/{user}/{repo}/raw/{commit}/{path} format. This is
not compatible with OAuth authentication.

By changing the URL's produced to the 2.0 REST API format, this should
allow VS to succesfully authenticate to private BitBucket Cloud Repo's
when using 2FA.