### PR TITLE
Normalize git commondir path.

### DIFF
--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -491,6 +491,8 @@ namespace Microsoft.Build.Tasks.Git
                 try
                 {
                     commonDirectory = Path.Combine(directory, File.ReadAllText(commonLinkPath).TrimEnd(CharUtils.AsciiWhitespace));
+                    // Normalize relative paths. For example, git worktrees typically have "../.." in this file.
+                    commonDirectory = Path.GetFullPath(commonDirectory);
                 }
                 catch
                 {


### PR DESCRIPTION
The constructor for GitRepositoryLocation asserts that this path is
normalized. On my machine, a git worktree created by Git 2.22.0 does not
result in path that satisfies this assert.

Fixes https://github.com/dotnet/sourcelink/issues/473