### PR TITLE
Use submodule.name.url to determine the URL of a submodule

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -220,7 +220,7 @@ for Source Link to operate properly.
 
   configuration file that specifies `origin` remote URL (e.g. `[remote "origin"] url="http://server.com/repo"`)
 
-If the repository has submodules the file `.gitmodules` must be present in the repository root and must list the URLs and 
+If the repository has submodules the file `.gitmodules` must be present in the repository root and must list the 
 relative paths of all submodules.
 
 For example,
@@ -228,6 +228,14 @@ For example,
 ```
 [submodule "submodule-name"]
   path = submodule-path
+```
+
+The `.git/config` file must contain the URL of all initialized submodules:
+ 
+For example,
+
+```
+[submodule "submodule-name"]
   url = https://server.com/subrepo
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -228,7 +228,7 @@ relative paths of all submodules:
   path = submodule-path
 ```
 
-The `.git/config` file must contain the URL of all initialized submodules:
+The `.git/config` file must contain URLs of all initialized submodules:
 
 ```
 [submodule "submodule-name"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -221,9 +221,7 @@ for Source Link to operate properly.
   configuration file that specifies `origin` remote URL (e.g. `[remote "origin"] url="http://server.com/repo"`)
 
 If the repository has submodules the file `.gitmodules` must be present in the repository root and must list the 
-relative paths of all submodules.
-
-For example,
+relative paths of all submodules:
 
 ```
 [submodule "submodule-name"]
@@ -231,8 +229,6 @@ For example,
 ```
 
 The `.git/config` file must contain the URL of all initialized submodules:
- 
-For example,
 
 ```
 [submodule "submodule-name"]

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
@@ -20,7 +20,12 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
 
             var gitDir = repoDir.CreateDirectory(".git");
             gitDir.CreateFile("HEAD").WriteAllText("1111111111111111111111111111111111111111");
-            gitDir.CreateFile("config").WriteAllText(@"[remote ""origin""]url=""http://github.com/test-org/test-repo""");
+            gitDir.CreateFile("config").WriteAllText(@"
+[remote ""origin""]
+url=http://github.com/test-org/test-repo
+[submodule ""my submodule""]
+url=https://github.com/test-org/test-sub
+");
             gitDir.CreateDirectory("objects");
             gitDir.CreateDirectory("refs");
             repoDir.CreateFile(".gitignore").WriteAllText("ignore_this_*");
@@ -29,7 +34,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var gitModules = repoDir.CreateFile(".gitmodules").WriteAllText(@"
 [submodule ""my submodule""]
   path = sub
-  url = https://github.com/test-org/test-sub
+  url = xyz
 ");
             
             var subDir = repoDir.CreateDirectory("sub");

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -295,8 +295,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             {
                 "S10: 'sub10' 'http://github.com'",
                 "S11: 'sub11' 'http://github.com'",
-                "S9: 'sub9' 'http://github.com'",
-                "S4: 'sub4' '   '"
+                "S9: 'sub9' 'http://github.com'"
             }, submodules.Select(s => $"{s.Name}: '{s.WorkingDirectoryRelativePath}' '{s.Url}'"));
 
             var diagnostics = repository.GetSubmoduleDiagnostics();
@@ -308,6 +307,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
               string.Format(Resources.InvalidSubmodulePath, "S2", ""),
               // Could not find a part of the path 'sub3\.git'.
               TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub3", ".git"))),
+              // Could not find a part of the path 'sub4\.git'.
+              TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub4", ".git"))),
               // Could not find a part of the path 'sub5\.git'.
               TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub5", ".git"))),
               // Access to the path 'sub6\.git' is denied

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -295,7 +295,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             {
                 "S10: 'sub10' 'http://github.com'",
                 "S11: 'sub11' 'http://github.com'",
-                "S9: 'sub9' 'http://github.com'"
+                "S9: 'sub9' 'http://github.com'",
+                "S4: 'sub4' '   '"
             }, submodules.Select(s => $"{s.Name}: '{s.WorkingDirectoryRelativePath}' '{s.Url}'"));
 
             var diagnostics = repository.GetSubmoduleDiagnostics();
@@ -307,8 +308,6 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
               string.Format(Resources.InvalidSubmodulePath, "S2", ""),
               // Could not find a part of the path 'sub3\.git'.
               TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub3", ".git"))),
-              // The URL of submodule 'S4' is missing or invalid: '   '
-              string.Format(Resources.InvalidSubmoduleUrl, "S4", "   "),
               // Could not find a part of the path 'sub5\.git'.
               TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub5", ".git"))),
               // Access to the path 'sub6\.git' is denied

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -261,11 +261,7 @@ namespace Microsoft.Build.Tasks.Git
                     continue;
                 }
 
-                if (NullableString.IsNullOrWhiteSpace(url))
-                {
-                    reportDiagnostic(string.Format(Resources.InvalidSubmoduleUrl, name, url));
-                    continue;
-                }
+                // Ignore unspecified URL - Source Link doesn't use it.
 
                 string fullPath;
                 try

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitSubmodule.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitSubmodule.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Build.Tasks.Git
 {
@@ -21,21 +20,20 @@ namespace Microsoft.Build.Tasks.Git
         public string WorkingDirectoryFullPath { get; }
 
         /// <summary>
-        /// An absolute URL or a relative path (if it starts with `./` or `../`) to the default remote of the containing repository.
+        /// An absolute URL or a relative path (if it starts with `./` or `../`) to the origin remote of the containing repository.
         /// </summary>
-        public string Url { get; }
+        public string? Url { get; }
 
         /// <summary>
         /// Head tip commit SHA. Null, if there is no commit.
         /// </summary>
         public string? HeadCommitSha { get; }
 
-        internal GitSubmodule(string name, string workingDirectoryRelativePath, string workingDirectoryFullPath, string url, string? headCommitSha)
+        internal GitSubmodule(string name, string workingDirectoryRelativePath, string workingDirectoryFullPath, string? url, string? headCommitSha)
         {
             NullableDebug.Assert(name != null);
             NullableDebug.Assert(workingDirectoryRelativePath != null);
             NullableDebug.Assert(workingDirectoryFullPath != null);
-            NullableDebug.Assert(url != null);
 
             Name = name;
             WorkingDirectoryRelativePath = workingDirectoryRelativePath;


### PR DESCRIPTION
Check `submodule.<name>.url` configuration variable to find the URL for the submodule (see https://git-scm.com/docs/gitsubmodules). This variable is calculated based on the entry in `.gitmodules` by `git submodule init` and will be present for initialized submodules. Skip uninitialized submodules as they won't have source code contributing to the build. 

Fixes #576 