### PR TITLE
Allow using .git directory instead of gitdir redirect in submodules.

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -295,6 +295,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             {
                 "S10: 'sub10' 'http://github.com'",
                 "S11: 'sub11' 'http://github.com'",
+                "S6: 'sub6' 'http://github.com'",
                 "S9: 'sub9' 'http://github.com'"
             }, submodules.Select(s => $"{s.Name}: '{s.WorkingDirectoryRelativePath}' '{s.Url}'"));
 
@@ -311,8 +312,6 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
               TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub4", ".git"))),
               // Could not find a part of the path 'sub5\.git'.
               TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub5", ".git"))),
-              // Access to the path 'sub6\.git' is denied
-              TestUtilities.GetExceptionMessage(() => File.ReadAllText(Path.Combine(workingDir.Path, "sub6", ".git"))),
               // The format of the file 'sub7\.git' is invalid.
               string.Format(Resources.FormatOfFileIsInvalid, Path.Combine(workingDir.Path, "sub7", ".git")),
               // Path specified in file 'sub8\.git' is invalid.

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -344,14 +344,26 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var gitDir = temp.CreateDirectory();
             var workingDir = temp.CreateDirectory();
 
-            var basicSubmoduleGitDir = temp.CreateDirectory();
+            var submoduleGitDir = temp.CreateDirectory();
 
-            var basicSubmoduleWorkingDir = workingDir.CreateDirectory("sub").CreateDirectory("abc");
-            basicSubmoduleWorkingDir.CreateFile(".git").WriteAllText("gitdir: " + basicSubmoduleGitDir.Path + "\t \v\f\r\n\n\r");
+            var submoduleWorkingDir = workingDir.CreateDirectory("sub").CreateDirectory("abc");
+            submoduleWorkingDir.CreateFile(".git").WriteAllText("gitdir: " + submoduleGitDir.Path + "\t \v\f\r\n\n\r");
 
-            var basicSubmoduleRefsHeadsDir = basicSubmoduleGitDir.CreateDirectory("refs").CreateDirectory("heads");
-            basicSubmoduleRefsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
-            basicSubmoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
+            var submoduleRefsHeadsDir = submoduleGitDir.CreateDirectory("refs").CreateDirectory("heads");
+            submoduleRefsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
+            submoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
+
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
+            Assert.Equal("0000000000000000000000000000000000000000", repository.ReadSubmoduleHeadCommitSha(submoduleWorkingDir.Path));
+        }
+
+        [Fact]
+        public void GetOldStyleSubmoduleHeadCommitSha()
+        {
+            using var temp = new TempRoot();
+
+            var gitDir = temp.CreateDirectory();
+            var workingDir = temp.CreateDirectory();
 
             // this is a unusual but legal case which can occur with older versions of Git or other tools.
             // see https://git-scm.com/docs/gitsubmodules#_forms for more details.
@@ -362,7 +374,6 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             oldStyleSubmoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/branch1");
 
             var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
-            Assert.Equal("0000000000000000000000000000000000000000", repository.ReadSubmoduleHeadCommitSha(basicSubmoduleWorkingDir.Path));
             Assert.Equal("1111111111111111111111111111111111111111", repository.ReadSubmoduleHeadCommitSha(oldStyleSubmoduleWorkingDir.Path));
         }
     }

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -344,17 +344,26 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var gitDir = temp.CreateDirectory();
             var workingDir = temp.CreateDirectory();
 
-            var submoduleGitDir = temp.CreateDirectory();
+            var basicSubmoduleGitDir = temp.CreateDirectory();
 
-            var submoduleWorkingDir = workingDir.CreateDirectory("sub").CreateDirectory("abc");
-            submoduleWorkingDir.CreateFile(".git").WriteAllText("gitdir: " + submoduleGitDir.Path + "\t \v\f\r\n\n\r");
+            var basicSubmoduleWorkingDir = workingDir.CreateDirectory("sub").CreateDirectory("abc");
+            basicSubmoduleWorkingDir.CreateFile(".git").WriteAllText("gitdir: " + basicSubmoduleGitDir.Path + "\t \v\f\r\n\n\r");
 
-            var submoduleRefsHeadsDir = submoduleGitDir.CreateDirectory("refs").CreateDirectory("heads");
-            submoduleRefsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
-            submoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
+            var basicSubmoduleRefsHeadsDir = basicSubmoduleGitDir.CreateDirectory("refs").CreateDirectory("heads");
+            basicSubmoduleRefsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
+            basicSubmoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
+
+            // this is a unusual but legal case which can occur with older versions of Git or other tools.
+            // see https://git-scm.com/docs/gitsubmodules#_forms for more details.
+            var oldStyleSubmoduleWorkingDir = workingDir.CreateDirectory("old-style-submodule");
+            var oldStyleSubmoduleGitDir = oldStyleSubmoduleWorkingDir.CreateDirectory(".git");
+            var oldStyleSubmoduleRefsHeadDir = oldStyleSubmoduleGitDir.CreateDirectory("refs").CreateDirectory("heads");
+            oldStyleSubmoduleRefsHeadDir.CreateFile("branch1").WriteAllText("1111111111111111111111111111111111111111");
+            oldStyleSubmoduleGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/branch1");
 
             var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, gitDir.Path, workingDir.Path);
-            Assert.Equal("0000000000000000000000000000000000000000", repository.ReadSubmoduleHeadCommitSha(submoduleWorkingDir.Path));
+            Assert.Equal("0000000000000000000000000000000000000000", repository.ReadSubmoduleHeadCommitSha(basicSubmoduleWorkingDir.Path));
+            Assert.Equal("1111111111111111111111111111111111111111", repository.ReadSubmoduleHeadCommitSha(oldStyleSubmoduleWorkingDir.Path));
         }
     }
 }

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -213,15 +213,10 @@ namespace Microsoft.Build.Tasks.Git
             // This can occur with older versions of Git or other tools, or when a user clones one
             // repo into another's source tree (but it was not yet registered as a submodule).
             // See https://git-scm.com/docs/gitsubmodules#_forms for more details.
-            // Handle this case first since the other case throws.
             var dotGitPath = Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName);
 
-            var gitDirectory =
-                Directory.Exists(dotGitPath) ? dotGitPath :
-                File.Exists(dotGitPath) ? ReadDotGitFile(dotGitPath) :
-                null;
-
-            if (gitDirectory == null || !IsGitDirectory(gitDirectory, out var commonDirectory))
+            var gitDirectory = Directory.Exists(dotGitPath) ? dotGitPath : ReadDotGitFile(dotGitPath);
+            if (!IsGitDirectory(gitDirectory, out var commonDirectory))
             {
                 return null;
             }

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -209,8 +209,10 @@ namespace Microsoft.Build.Tasks.Git
         /// <returns>Null if the HEAD tip reference can't be resolved.</returns>
         internal string? ReadSubmoduleHeadCommitSha(string submoduleWorkingDirectoryFullPath)
         {
-            // submodules don't usually have their own .git directories but this is still legal.
-            // see https://git-scm.com/docs/gitsubmodules#_forms for more details.
+            // Submodules don't usually have their own .git directories but this is still legal.
+            // This can occur with older versions of Git or other tools, or when a user clones one
+            // repo into another's source tree (but it was not yet registered as a submodule).
+            // See https://git-scm.com/docs/gitsubmodules#_forms for more details.
             // Handle this case first since the other case throws.
             var dotGitPath = Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName);
             if (IsGitDirectory(dotGitPath, out var directSubmoduleGitDirectory))

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -209,8 +209,9 @@ namespace Microsoft.Build.Tasks.Git
         /// <returns>Null if the HEAD tip reference can't be resolved.</returns>
         internal string? ReadSubmoduleHeadCommitSha(string submoduleWorkingDirectoryFullPath)
         {
-            // submodules don't usually have their own .git directories but can when Arcade uberclone
-            // was used.  Handle this case first since the other case throws.
+            // submodules don't usually have their own .git directories but this is still legal.
+            // see https://git-scm.com/docs/gitsubmodules#_forms for more details.
+            // Handle this case first since the other case throws.
             var dotGitPath = Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName);
             if (IsGitDirectory(dotGitPath, out var directSubmoduleGitDirectory))
             {

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -215,14 +215,13 @@ namespace Microsoft.Build.Tasks.Git
             // See https://git-scm.com/docs/gitsubmodules#_forms for more details.
             // Handle this case first since the other case throws.
             var dotGitPath = Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName);
-            if (IsGitDirectory(dotGitPath, out var directSubmoduleGitDirectory))
-            {
-                var submoduleGitDirResolver = new GitReferenceResolver(directSubmoduleGitDirectory, directSubmoduleGitDirectory);
-                return submoduleGitDirResolver.ResolveHeadReference();
-            }
 
-            var gitDirectory = ReadDotGitFile(Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName));
-            if (!IsGitDirectory(gitDirectory, out var commonDirectory))
+            var gitDirectory =
+                Directory.Exists(dotGitPath) ? dotGitPath :
+                File.Exists(dotGitPath) ? ReadDotGitFile(dotGitPath) :
+                null;
+
+            if (gitDirectory == null || !IsGitDirectory(gitDirectory, out var commonDirectory))
             {
                 return null;
             }

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Build.Tasks.Git
             var dotGitPath = Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName);
             if (IsGitDirectory(dotGitPath, out var directSubmoduleGitDirectory))
             {
-                var submoduleGitDirResolver = new GitReferenceResolver(directSubmoduleGitDirectory, submoduleWorkingDirectoryFullPath);
+                var submoduleGitDirResolver = new GitReferenceResolver(directSubmoduleGitDirectory, directSubmoduleGitDirectory);
                 return submoduleGitDirResolver.ResolveHeadReference();
             }
 

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -209,6 +209,15 @@ namespace Microsoft.Build.Tasks.Git
         /// <returns>Null if the HEAD tip reference can't be resolved.</returns>
         internal string? ReadSubmoduleHeadCommitSha(string submoduleWorkingDirectoryFullPath)
         {
+            // submodules don't usually have their own .git directories but can when Arcade uberclone
+            // was used.  Handle this case first since the other case throws.
+            var dotGitPath = Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName);
+            if (IsGitDirectory(dotGitPath, out var directSubmoduleGitDirectory))
+            {
+                var submoduleGitDirResolver = new GitReferenceResolver(directSubmoduleGitDirectory, submoduleWorkingDirectoryFullPath);
+                return submoduleGitDirResolver.ResolveHeadReference();
+            }
+
             var gitDirectory = ReadDotGitFile(Path.Combine(submoduleWorkingDirectoryFullPath, GitDirName));
             if (!IsGitDirectory(gitDirectory, out var commonDirectory))
             {


### PR DESCRIPTION
This is not a scenario for normal git repos, but is still legal, and the Arcade uberclone purposely uses this scenario for minimal SourceLink metadata.