### PR TITLE
Fix broken link in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ By setting `DeterministicSourcePaths` to true the project opts into mapping all 
 Only set `DeterministicSourcePaths` to true on a build/CI server, never for local builds.
 In order for the debugger to find source files when debugging a locally built binary, the PDB must contain original, unmapped local paths.
 
-Starting with .NET Core SDK 2.1.300, a fully deterministic build is [turned on](https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets#L45-L55) when both `Deterministic` and `ContinuousIntegrationBuild` properties are set to `true`. 
+Starting with .NET Core SDK 2.1.300, a fully deterministic build is [turned on](https://github.com/dotnet/roslyn/blob/Visual-Studio-2019-Version-16.7.3/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets#L131-L141) when both `Deterministic` and `ContinuousIntegrationBuild` properties are set to `true`. 
 
 ## Example
 


### PR DESCRIPTION
The link was pointing to the master branch so the line numbers have changed on master since then. The new link points to a tag to ensure that line numbers won't change in the future.