### PR TITLE
Allow retrieval of the "relative file path" from the source link map

### DIFF
--- a/src/SourceLink.Tools.UnitTests/SourceLinkMapTests.cs
+++ b/src/SourceLink.Tools.UnitTests/SourceLinkMapTests.cs
@@ -66,11 +66,23 @@ namespace Microsoft.SourceLink.Tools.UnitTests
             Assert.True(map.TryGetUri(@"C:\a", out var url));
             Assert.Equal("http://server/[]", url);
 
+            Assert.True(map.TryGetUri(@"C:\a", out url, out var relativeFilePath));
+            Assert.Equal("http://server/[]", url);
+            Assert.Equal("", relativeFilePath);
+
             Assert.True(map.TryGetUri(@"C:\a\b\c\d\e", out url));
             Assert.Equal("http://server/[/b/c/d/e]", url);
 
+            Assert.True(map.TryGetUri(@"C:\a\b\c\d\e", out url, out relativeFilePath));
+            Assert.Equal("http://server/[/b/c/d/e]", url);
+            Assert.Equal(@"/b/c/d/e", relativeFilePath);
+
             Assert.True(map.TryGetUri(@"C:\b", out url));
             Assert.Equal("http://b", url);
+
+            Assert.True(map.TryGetUri(@"C:\b", out url, out relativeFilePath));
+            Assert.Equal("http://b", url);
+            Assert.Equal("b", relativeFilePath);
 
             Assert.False(map.TryGetUri(@"C:\b\c", out _));
         }

--- a/src/SourceLink.Tools/SourceLinkMap.cs
+++ b/src/SourceLink.Tools/SourceLinkMap.cs
@@ -190,6 +190,24 @@ namespace Microsoft.SourceLink.Tools
 #endif
             out string? uri)
         {
+            return TryGetUri(path, out uri, out _);
+        }
+
+        /// <summary>
+        /// Maps specified <paramref name="path"/> to the corresponding URL.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+        public bool TryGetUri(
+            string path,
+#if NETCOREAPP
+            [NotNullWhen(true)]
+#endif
+            out string? uri,
+#if NETCOREAPP
+            [NotNullWhen(true)]
+#endif
+            out string? relativeFilePath)
+        {
             if (path == null)
             {
                 throw new ArgumentNullException(nameof(path));
@@ -198,6 +216,7 @@ namespace Microsoft.SourceLink.Tools
             if (path.IndexOf('*') >= 0)
             {
                 uri = null;
+                relativeFilePath = null;
                 return false;
             }
 
@@ -209,20 +228,24 @@ namespace Microsoft.SourceLink.Tools
                 {
                     if (path.StartsWith(file.Path, StringComparison.OrdinalIgnoreCase))
                     {
-                        var escapedPath = string.Join("/", path.Substring(file.Path.Length).Split(new[] { '/', '\\' }).Select(Uri.EscapeDataString));
+                        var relativePath = path.Substring(file.Path.Length).Replace('\\', '/');
+                        var escapedPath = string.Join("/", relativePath.Split('/').Select(Uri.EscapeDataString));
                         uri = mappedUri.Prefix + escapedPath + mappedUri.Suffix;
+                        relativeFilePath = relativePath;
                         return true;
                     }
                 }
                 else if (string.Equals(path, file.Path, StringComparison.OrdinalIgnoreCase))
                 {
                     Debug.Assert(mappedUri.Suffix.Length == 0);
+                    relativeFilePath = Path.GetFileName(file.Path);
                     uri = mappedUri.Prefix;
                     return true;
                 }
             }
 
             uri = null;
+            relativeFilePath = null;
             return false;
         } 
     }


### PR DESCRIPTION
It can be helpful for consumers of the Source Link to know what portion
of the file path provided to the query is substituted into the URL. One
example is for building a heuristic file path on disk to store the
downloaded source link file to. This relative path can give end users
more context on where the file is located in the original repository.

This change add a new TryGetUri overload that provides the "relative
file path" as another out param. It also updates the tests to add
coverage for this.