### PR TITLE
Add support for the new GitLab raw url

### DIFF
--- a/src/SourceLink.GitLab/GetSourceLinkUrl.cs
+++ b/src/SourceLink.GitLab/GetSourceLinkUrl.cs
@@ -18,7 +18,33 @@ namespace Microsoft.SourceLink.GitLab
         protected override string HostsItemGroupName => "SourceLinkGitLabHost";
         protected override string ProviderDisplayName => "GitLab";
 
+        private const string VersionMetadataName = "Version";
+
+        // see https://gitlab.com/gitlab-org/gitlab/-/issues/28848
+        private static readonly Version s_versionWithNewUrlFormat = new Version(12, 0);
+
         protected override string? BuildSourceLinkUrl(Uri contentUri, Uri gitUri, string relativeUrl, string revisionId, ITaskItem? hostItem)
-            => UriUtilities.Combine(UriUtilities.Combine(contentUri.ToString(), relativeUrl), "raw/" + revisionId + "/*");
+        {
+            var path = GetVersion(hostItem) >= s_versionWithNewUrlFormat
+                ? "-/raw/" + revisionId + "/*"
+                : "raw/" + revisionId + "/*";
+            return UriUtilities.Combine(UriUtilities.Combine(contentUri.ToString(), relativeUrl), path);
+        }
+
+        private Version GetVersion(ITaskItem? hostItem)
+        {
+            var versionAsString = hostItem?.GetMetadata(VersionMetadataName);
+            if (!NullableString.IsNullOrEmpty(versionAsString))
+            {
+                if (Version.TryParse(versionAsString, out var version))
+                {
+                    return version;
+                }
+
+                Log.LogError(CommonResources.ItemOfItemGroupMustSpecifyMetadata, hostItem!.ItemSpec, HostsItemGroupName, VersionMetadataName);
+            }
+
+            return s_versionWithNewUrlFormat;
+        }
     }
 }


### PR DESCRIPTION
In GitLab 13.5 (at least) the url changed from, e.g.:

https://gitlab.example.com/raw/example/example-dotnet-source-link/538b7a2b0d086146a6534bfe6f98a379191ea529/ExampleApplication/Program.cs

To:

https://gitlab.example.com/example/example-dotnet-source-link/-/raw/538b7a2b0d086146a6534bfe6f98a379191ea529/ExampleApplication/Program.cs

This closes #670.