### PR TITLE
Fix discovery of working directory for worktrees

### DIFF
--- a/src/Microsoft.Build.Tasks.Git/GitOperations.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitOperations.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Build.Tasks.Git
             public readonly string Name;
             public readonly List<DirectoryNode> OrderedChildren;
 
-            // set on nodes that represent submodule working directory:
+            // set on nodes that represent working directory of the repository or a submodule:
             public Lazy<GitIgnore.Matcher?>? Matcher;
 
             public DirectoryNode(string name, List<DirectoryNode> orderedChildren)


### PR DESCRIPTION
SourceLink used gitdir to determine the directory (and incorrectly interpreting the content) but turns out git doesn't use it at all for this purpose.

Fixes https://github.com/dotnet/roslyn/issues/55149