### PR TITLE
Add sparse checkout support

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -210,6 +210,32 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         }
 
         [Fact]
+        public void OpenRepository_SparseV2()
+        {
+            using var temp = new TempRoot();
+
+            var workingDir = temp.CreateDirectory();
+            var gitDir = workingDir.CreateDirectory(".git");
+
+            gitDir.CreateFile("HEAD");
+            gitDir.CreateFile("config").WriteAllText(@"
+[core]
+	repositoryformatversion = 1
+[extensions]
+	worktreeConfig = true");
+
+            Assert.True(GitRepository.TryFindRepository(gitDir.Path, out var location));
+            Assert.Equal(gitDir.Path, location.CommonDirectory);
+            Assert.Equal(gitDir.Path, location.GitDirectory);
+            Assert.Null(location.WorkingDirectory);
+
+            var repository = GitRepository.OpenRepository(location, GitEnvironment.Empty);
+            Assert.Equal(gitDir.Path, repository.CommonDirectory);
+            Assert.Equal(gitDir.Path, repository.GitDirectory);
+            Assert.Null(repository.WorkingDirectory);
+        }
+
+        [Fact]
         public void OpenRepository_VersionNotSupported()
         {
             using var temp = new TempRoot();
@@ -223,7 +249,32 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             gitDir.CreateDirectory("refs").CreateDirectory("heads").CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
             gitDir.CreateDirectory("objects");
 
-            gitDir.CreateFile("config").WriteAllText("[core]repositoryformatversion = 1");
+            gitDir.CreateFile("config").WriteAllText("[core]repositoryformatversion = 2");
+
+            var src = workingDir.CreateDirectory("src");
+
+            Assert.Throws<NotSupportedException>(() => GitRepository.OpenRepository(src.Path, new GitEnvironment(homeDir.Path)));
+        }
+
+        [Fact]
+        public void OpenRepository_V2ExtensionNotSupported()
+        {
+            using var temp = new TempRoot();
+
+            var homeDir = temp.CreateDirectory();
+
+            var workingDir = temp.CreateDirectory();
+            var gitDir = workingDir.CreateDirectory(".git");
+
+            gitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master");
+            gitDir.CreateDirectory("refs").CreateDirectory("heads").CreateFile("master").WriteAllText("0000000000000000000000000000000000000000");
+            gitDir.CreateDirectory("objects");
+
+            gitDir.CreateFile("config").WriteAllText(@"
+[core]
+	repositoryformatversion = 1
+[extensions]
+	newExtension = true");
 
             var src = workingDir.CreateDirectory("src");
 

--- a/src/Microsoft.Build.Tasks.Git/Resources.resx
+++ b/src/Microsoft.Build.Tasks.Git/Resources.resx
@@ -129,6 +129,9 @@
   <data name="UnsupportedRepositoryVersion" xml:space="preserve">
     <value>Unsupported repository version {0}. Only versions up to {1} are supported.</value>
   </data>
+  <data name="UnsupportedRepositoryExtension" xml:space="preserve">
+    <value>Unsupported repository extension {0}. Only {1} are supported.</value>
+  </data>
   <data name="PathSpecifiedInFileIsNotAbsolute" xml:space="preserve">
     <value>Path specified in file '{0}' is not absolute: '{1}'.</value>
   </data>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.cs.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.cs.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Nejde najít úložiště s pracovním adresářem, který obsahuje adresář {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">Nepodporovaná verze úložiště: {0}. Podporují se jenom verze do {1}.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.de.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.de.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Das Repository mit dem Arbeitsverzeichnis, welches das Verzeichnis "{0}" enthält, wurde nicht gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">Nicht unterstützte Repositoryversion {0}. Nur Versionen bis {1} werden unterstützt.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.es.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.es.xlf
@@ -117,6 +117,11 @@
         <target state="translated">No se puede encontrar el repositorio con el directorio de trabajo que contiene el directorio "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">Versión de repositorio {0} no admitida. Solo se admiten las versiones hasta {1}.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.fr.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.fr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Impossible de localiser le dépôt avec le répertoire de travail contenant le répertoire '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">La version du dépôt {0} n'est pas prise en charge. Seules les versions jusqu'à {1} sont prises en charge.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.it.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.it.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Non è possibile individuare il repository con la directory di lavoro che contiene la directory '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">La versione {0} del repository non è supportata. Sono supportate solo le versioni fino alla {1}.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ja.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ja.xlf
@@ -117,6 +117,11 @@
         <target state="translated">ディレクトリ '{0}' を含む作業ディレクトリがあるリポジトリが見つかりません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">サポートされていないリポジトリ バージョン {0}。{1} までのバージョンのみがサポートされています。</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ko.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ko.xlf
@@ -117,6 +117,11 @@
         <target state="translated">디렉터리 '{0}'이(가) 포함된 작업 디렉터리로 리포지토리를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">{0}은(는) 지원되지 않는 리포지토리 버전입니다. 버전은 최대 {1}까지만 지원됩니다.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.pl.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.pl.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Nie można zlokalizować repozytorium z katalogiem roboczym zawierającym katalog „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">Nieobsługiwana wersja repozytorium {0}. Obsługiwane są tylko wersje do {1}.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.pt-BR.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Não é possível localizar o repositório com o diretório de trabalho que contém o diretório '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">{0} de versão do repositório sem suporte. Há suporte apenas para versões de até {1}.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ru.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ru.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Не удается найти репозиторий с рабочим каталогом, содержащим каталог "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">Неподдерживаемая версия репозитория {0}. Поддерживаются только версии до {1}.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.tr.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.tr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">'{0}' dizinini içeren çalışma dizini içeren depo bulunamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">{0} depo sürümü desteklenmiyor. Yalnızca {1} sürümüne kadar olan sürümler desteklenir.</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hans.xlf
@@ -117,6 +117,11 @@
         <target state="translated">找不到具有带目录“{0}”的工作目录的存储库。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">不支持存储库版本 {0}。支持的最高版本为 {1}。</target>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hant.xlf
@@ -117,6 +117,11 @@
         <target state="translated">找不到具有包含目錄 '{0}' 之工作目錄的存放庫。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnsupportedRepositoryExtension">
+        <source>Unsupported repository extension {0}. Only {1} are supported.</source>
+        <target state="new">Unsupported repository extension {0}. Only {1} are supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedRepositoryVersion">
         <source>Unsupported repository version {0}. Only versions up to {1} are supported.</source>
         <target state="translated">不支援的存放庫版本 {0}。最大只支援版本 {1}。</target>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sourcelink/issues/771

Reads but does not interpret any of V1 extensions. The only one of interest is the `worktreeConfig` which I didn't implement because `config.worktree` didn't seem to contain any information of interest.

Sample sparse repo config:

```
config.worktree

[core]
	sparseCheckout = true

config

[core]
	repositoryformatversion = 1
	filemode = false
	bare = false
	logallrefupdates = true
	symlinks = false
	ignorecase = true
[remote "origin"]
	url = https://github.com/Azure/azure-sdk-for-net
	fetch = +refs/heads/*:refs/remotes/origin/*
	promisor = true
	partialclonefilter = tree:0
[branch "main"]
	remote = origin
	merge = refs/heads/main
[extensions]
	worktreeConfig = true
```
