### PR TITLE
Add support for Gitee

### DIFF
--- a/SourceLink.sln
+++ b/SourceLink.sln
@@ -70,6 +70,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SourceLink.Gitea.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-sourcelink", "src\dotnet-sourcelink\dotnet-sourcelink.csproj", "{4376B613-CD5B-4274-9071-30989769B0B2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SourceLink.Gitee", "src\SourceLink.Gitee\Microsoft.SourceLink.Gitee.csproj", "{EBB5B478-BD04-4E82-9C06-BE8C24EEB55F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SourceLink.Gitee.UnitTests", "src\SourceLink.Gitee.UnitTests\Microsoft.SourceLink.Gitee.UnitTests.csproj", "{D647294C-40C0-4624-A76B-C4C276233609}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\SourceLink.Tools\Microsoft.SourceLink.Tools.projitems*{4376b613-cd5b-4274-9071-30989769b0b2}*SharedItemsImports = 5
@@ -185,6 +189,14 @@ Global
 		{4376B613-CD5B-4274-9071-30989769B0B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4376B613-CD5B-4274-9071-30989769B0B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4376B613-CD5B-4274-9071-30989769B0B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBB5B478-BD04-4E82-9C06-BE8C24EEB55F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBB5B478-BD04-4E82-9C06-BE8C24EEB55F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBB5B478-BD04-4E82-9C06-BE8C24EEB55F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBB5B478-BD04-4E82-9C06-BE8C24EEB55F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D647294C-40C0-4624-A76B-C4C276233609}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D647294C-40C0-4624-A76B-C4C276233609}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D647294C-40C0-4624-A76B-C4C276233609}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D647294C-40C0-4624-A76B-C4C276233609}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System.IO;
+using TestUtilities;
+
+namespace Microsoft.SourceLink.IntegrationTests
+{
+    public class GiteeTests : DotNetSdkTestBase
+    {
+        public GiteeTests()
+            : base("Microsoft.SourceLink.Gitee")
+        {
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void FullValidation_Https()
+        {
+            // Test non-ascii characters and escapes in the URL.
+            // Escaped URI reserved characters should remain escaped, non-reserved characters unescaped in the results.
+            var repoUrl = "https://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
+            var repoName = "test-repo\u1234%24%2572%2F";
+
+            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var commitSha = repo.Head.Tip.Sha;
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+  <PublishRepositoryUrl>true</PublishRepositoryUrl>
+</PropertyGroup>
+<ItemGroup>
+  <SourceLinkGiteeHost Include='噸.com'/>
+</ItemGroup>
+",
+                customTargets: "",
+                targets: new[]
+                {
+                    "Build", "Pack"
+                },
+                expressions: new[]
+                {
+                    "@(SourceRoot)",
+                    "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "$(SourceLink)",
+                    "$(PrivateRepositoryUrl)",
+                    "$(RepositoryUrl)"
+                },
+                expectedResults: new[]
+                {
+                    NuGetPackageFolders,
+                    ProjectSourceRoot,
+                    $"https://噸.com/test-org/{repoName}/raw/{commitSha}/*",
+                    s_relativeSourceLinkJsonPath,
+                    $"https://噸.com/test-org/{repoName}",
+                    $"https://噸.com/test-org/{repoName}"
+                });
+
+            AssertEx.AreEqual(
+                $@"{{""documents"":{{""{ProjectSourceRoot.Replace(@"\", @"\\")}*"":""https://噸.com/test-org/{repoName}/raw/{commitSha}/*""}}}}",
+                File.ReadAllText(Path.Combine(ProjectDir.Path, s_relativeSourceLinkJsonPath)));
+
+            TestUtilities.ValidateAssemblyInformationalVersion(
+                Path.Combine(ProjectDir.Path, s_relativeOutputFilePath),
+                "1.0.0+" + commitSha);
+
+            TestUtilities.ValidateNuSpecRepository(
+                Path.Combine(ProjectDir.Path, s_relativePackagePath),
+                type: "git",
+                commit: commitSha,
+                url: $"https://噸.com/test-org/{repoName}");
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void FullValidation_Ssh()
+        {
+            // Test non-ascii characters and escapes in the URL.
+            // Escaped URI reserved characters should remain escaped, non-reserved characters unescaped in the results.
+            var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
+            var repoName = "test-repo\u1234%24%2572%2F";
+
+            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var commitSha = repo.Head.Tip.Sha;
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+  <PublishRepositoryUrl>true</PublishRepositoryUrl>
+</PropertyGroup>
+<ItemGroup>
+  <SourceLinkGiteeHost Include='噸.com'/>
+</ItemGroup>
+",
+                customTargets: "",
+                targets: new[]
+                {
+                    "Build", "Pack"
+                },
+                expressions: new[]
+                {
+                    "@(SourceRoot)",
+                    "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "$(SourceLink)",
+                    "$(PrivateRepositoryUrl)",
+                    "$(RepositoryUrl)"
+                },
+                expectedResults: new[]
+                {
+                    NuGetPackageFolders,
+                    ProjectSourceRoot,
+                    $"https://噸.com/test-org/{repoName}/raw/{commitSha}/*",
+                    s_relativeSourceLinkJsonPath,
+                    $"https://噸.com/test-org/{repoName}",
+                    $"https://噸.com/test-org/{repoName}"
+                });
+
+            AssertEx.AreEqual(
+                $@"{{""documents"":{{""{ProjectSourceRoot.Replace(@"\", @"\\")}*"":""https://噸.com/test-org/{repoName}/raw/{commitSha}/*""}}}}",
+                File.ReadAllText(Path.Combine(ProjectDir.Path, s_relativeSourceLinkJsonPath)));
+
+            TestUtilities.ValidateAssemblyInformationalVersion(
+                Path.Combine(ProjectDir.Path, s_relativeOutputFilePath),
+                "1.0.0+" + commitSha);
+
+            TestUtilities.ValidateNuSpecRepository(
+                Path.Combine(ProjectDir.Path, s_relativePackagePath),
+                type: "git",
+                commit: commitSha,
+                url: $"https://噸.com/test-org/{repoName}");
+        }
+
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void ImplicitHost()
+        {
+            // Test non-ascii characters and escapes in the URL.
+            // Escaped URI reserved characters should remain escaped, non-reserved characters unescaped in the results.
+            var repoUrl = "http://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
+            var repoName = "test-repo\u1234%24%2572%2F";
+
+            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var commitSha = repo.Head.Tip.Sha;
+
+            VerifyValues(
+                customProps: @"
+<PropertyGroup>
+  <PublishRepositoryUrl>true</PublishRepositoryUrl>
+</PropertyGroup>
+",
+                customTargets: "",
+                targets: new[]
+                {
+                    "Build", "Pack"
+                },
+                expressions: new[]
+                {
+                    "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "$(PrivateRepositoryUrl)",
+                    "$(RepositoryUrl)"
+                },
+                expectedResults: new[]
+                {
+                    $"http://噸.com/test-org/{repoName}/raw/{commitSha}/*",
+                    $"http://噸.com/test-org/{repoName}",
+                    $"http://噸.com/test-org/{repoName}"
+                });
+        }
+    }
+}

--- a/src/SourceLink.Gitee.UnitTests/GetSourceLinkUrlTests.cs
+++ b/src/SourceLink.Gitee.UnitTests/GetSourceLinkUrlTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.SourceLink.Gitee.UnitTests
 
             bool result = task.Execute();
             AssertEx.AssertEqualToleratingWhitespaceDifferences("", engine.Log);
-            AssertEx.AreEqual("https://domain.com/x/y/raw/a/b/0123456789abcdefABCDEF000000000000000000/*", task.SourceLinkUrl);
+            AssertEx.AreEqual("https://domain.com/x/y/a/b/raw/0123456789abcdefABCDEF000000000000000000/*", task.SourceLinkUrl);
             Assert.True(result);
         }
     }

--- a/src/SourceLink.Gitee.UnitTests/GetSourceLinkUrlTests.cs
+++ b/src/SourceLink.Gitee.UnitTests/GetSourceLinkUrlTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+using Microsoft.Build.Tasks.SourceControl;
+using TestUtilities;
+using Xunit;
+using static TestUtilities.KeyValuePairUtils;
+
+namespace Microsoft.SourceLink.Gitee.UnitTests
+{
+    public class GetSourceLinkUrlTests
+    {
+        [Fact]
+        public void EmptyHosts()
+        {
+            var engine = new MockEngine();
+
+            var task = new GetSourceLinkUrl()
+            {
+                BuildEngine = engine,
+                SourceRoot = new MockItem("x", KVP("RepositoryUrl", "http://abc.com"), KVP("SourceControl", "git")),
+            };
+
+            bool result = task.Execute();
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                "ERROR : " + string.Format(CommonResources.AtLeastOneRepositoryHostIsRequired, "SourceLinkGiteeHost", "Gitee"), engine.Log);
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("", "/")]
+        [InlineData("/", "")]
+        [InlineData("/", "/")]
+        public void BuildSourceLinkUrl(string s1, string s2)
+        {
+            var engine = new MockEngine();
+
+            var task = new GetSourceLinkUrl()
+            {
+                BuildEngine = engine,
+                SourceRoot = new MockItem("/src/", KVP("RepositoryUrl", "http://subdomain.mygitee.com:100/a/b" + s1), KVP("SourceControl", "git"), KVP("RevisionId", "0123456789abcdefABCDEF000000000000000000")),
+                Hosts = new[]
+                {
+                    new MockItem("mygitee.com", KVP("ContentUrl", "https://domain.com/x/y" + s2)),
+                }
+            };
+
+            bool result = task.Execute();
+            AssertEx.AssertEqualToleratingWhitespaceDifferences("", engine.Log);
+            AssertEx.AreEqual("https://domain.com/x/y/raw/a/b/0123456789abcdefABCDEF000000000000000000/*", task.SourceLinkUrl);
+            Assert.True(result);
+        }
+    }
+}

--- a/src/SourceLink.Gitee.UnitTests/Microsoft.SourceLink.Gitee.UnitTests.csproj
+++ b/src/SourceLink.Gitee.UnitTests/Microsoft.SourceLink.Gitee.UnitTests.csproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;net7.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SourceLink.Gitee\Microsoft.SourceLink.Gitee.csproj" />
+    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SourceLink.Gitee.UnitTests/TranslateRepositoryUrlsTests.cs
+++ b/src/SourceLink.Gitee.UnitTests/TranslateRepositoryUrlsTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.SourceLink.Gitee.UnitTests
             {
                 "https://gitee.com/a/b",
                 "ssh://gitee1.com/a/b",
-                "https://github1.com/a/b",
+                "https://gitee1.com/a/b",
                 "ssh://gitee2.com/a/b"
             }, task.TranslatedSourceRoots?.Select(r => r.GetMetadata("ScmRepositoryUrl")));
 

--- a/src/SourceLink.Gitee.UnitTests/TranslateRepositoryUrlsTests.cs
+++ b/src/SourceLink.Gitee.UnitTests/TranslateRepositoryUrlsTests.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+using System.Linq;
+using TestUtilities;
+using Xunit;
+using static TestUtilities.KeyValuePairUtils;
+
+namespace Microsoft.SourceLink.Gitee.UnitTests
+{
+    public class TranslateRepositoryUrlsTests
+    {
+        [Fact]
+        public void Translate()
+        {
+            var engine = new MockEngine();
+
+            var task = new TranslateRepositoryUrls()
+            {
+                BuildEngine = engine,
+                RepositoryUrl = "ssh://gitee.com/a/b",
+                IsSingleProvider = true,
+                SourceRoots = new[]
+                {
+                    new MockItem("/1/", KVP("SourceControl", "git"), KVP("ScmRepositoryUrl", "ssh://gitee.com:22/a/b")),
+                    new MockItem("/2/", KVP("SourceControl", "tfvc"), KVP("ScmRepositoryUrl", "ssh://gitee1.com/a/b")),
+                    new MockItem("/2/", KVP("SourceControl", "git"), KVP("ScmRepositoryUrl", "ssh://gitee1.com/a/b")),
+                    new MockItem("/2/", KVP("SourceControl", "tfvc"), KVP("ScmRepositoryUrl", "ssh://gitee2.com/a/b")),
+                },
+                Hosts = new[]
+                {
+                    new MockItem("gitee1.com")
+                }
+            };
+
+            bool result = task.Execute();
+            AssertEx.AssertEqualToleratingWhitespaceDifferences("", engine.Log);
+
+            AssertEx.AreEqual("https://gitee.com/a/b", task.TranslatedRepositoryUrl);
+
+            AssertEx.Equal(new[]
+            {
+                "https://gitee.com/a/b",
+                "ssh://gitee1.com/a/b",
+                "https://github1.com/a/b",
+                "ssh://gitee2.com/a/b"
+            }, task.TranslatedSourceRoots?.Select(r => r.GetMetadata("ScmRepositoryUrl")));
+
+            Assert.True(result);
+        }
+    }
+}

--- a/src/SourceLink.Gitee/GetSourceLinkUrl.cs
+++ b/src/SourceLink.Gitee/GetSourceLinkUrl.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks.SourceControl;
+
+namespace Microsoft.SourceLink.Gitee
+{
+    /// <summary>
+    /// The task calculates SourceLink URL for a given SourceRoot.
+    /// If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
+    /// output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
+    /// </summary>
+    public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
+    {
+        protected override string HostsItemGroupName => "SourceLinkGiteeHost";
+        protected override string ProviderDisplayName => "Gitee";
+
+        protected override Uri GetDefaultContentUriFromHostUri(string authority, Uri gitUri)
+            => new Uri($"{gitUri.Scheme}://{authority}", UriKind.Absolute);
+
+        protected override string? BuildSourceLinkUrl(Uri contentUri, Uri gitUri, string relativeUrl, string revisionId, ITaskItem? hostItem)
+            => UriUtilities.Combine(UriUtilities.Combine(contentUri.ToString(), relativeUrl), "raw/"+ revisionId + "/*");
+    }
+}

--- a/src/SourceLink.Gitee/Microsoft.SourceLink.Gitee.csproj
+++ b/src/SourceLink.Gitee/Microsoft.SourceLink.Gitee.csproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net7.0</TargetFrameworks>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+
+    <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
+    <IsPackable>true</IsPackable>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecBasePath>$(OutputPath)</NuspecBasePath>
+
+    <PackageDescription>Generates source link for Gitee repositories.</PackageDescription>
+    <PackageTags>MSBuild Tasks Gitee source link</PackageTags>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
+    <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
+    <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
+    <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
+    <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
+    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
+      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
+      <GenerateSource>true</GenerateSource>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.SourceLink.Gitee.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />
+  </ItemGroup>
+</Project>

--- a/src/SourceLink.Gitee/Microsoft.SourceLink.Gitee.nuspec
+++ b/src/SourceLink.Gitee/Microsoft.SourceLink.Gitee.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    $CommonMetadataElements$
+    <dependencies>
+      <dependency id="Microsoft.SourceLink.Common" version="$Version$" />
+      <dependency id="Microsoft.Build.Tasks.Git" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    $CommonFileElements$
+    <file src="$DesktopTfm$*\**\Microsoft.SourceLink.Gitee.*" exclude="**\*.config" target="tools" />
+    <file src="$CoreTfm$\**\Microsoft.SourceLink.Gitee.*" target="tools\core" />
+
+    <file src="$ProjectDirectory$\build\*.*" target="build" />
+    <file src="$ProjectDirectory$\buildMultiTargeting\*.*" target="buildMultiTargeting" />
+  </files>
+</package>

--- a/src/SourceLink.Gitee/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.Gitee/TranslateRepositoryUrls.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using Microsoft.Build.Tasks.SourceControl;
+
+namespace Microsoft.SourceLink.Gitee
+{
+    public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
+    {
+    }
+}

--- a/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.props
+++ b/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.props
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project>
+  <ItemGroup>
+    <SourceLinkGiteeHost Include="gitee.com" ContentUrl="https://gitee.com"/>
+  </ItemGroup>
+</Project>

--- a/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.targets
+++ b/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.targets
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project>
+  <PropertyGroup>
+    <_SourceLinkGiteeAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.Gitee.dll</_SourceLinkGiteeAssemblyFile>
+    <_SourceLinkGiteeAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.Gitee.dll</_SourceLinkGiteeAssemblyFile>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Microsoft.SourceLink.Gitee.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkGitHubAssemblyFile)"/>
+  <UsingTask TaskName="Microsoft.SourceLink.Gitee.TranslateRepositoryUrls" AssemblyFile="$(_SourceLinkGitHubAssemblyFile)"/>
+
+  <PropertyGroup>
+    <SourceLinkUrlInitializerTargets>$(SourceLinkUrlInitializerTargets);_InitializeGiteeSourceLinkUrl</SourceLinkUrlInitializerTargets>
+    <SourceControlManagerUrlTranslationTargets>$(SourceControlManagerUrlTranslationTargets);TranslateGiteeUrlsInSourceControlInformation</SourceControlManagerUrlTranslationTargets>
+  </PropertyGroup>
+
+  <Target Name="_InitializeGiteeSourceLinkUrl" Inputs="@(SourceRoot)" Outputs="|%(Identity)|">
+    <!--
+      The task calculates SourceLink URL for a given SourceRoot.
+
+      If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
+      output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
+
+      Recognized domains are specified via Hosts (initialized from SourceLinkGiteeHost item group).
+      In addition, if SourceLinkHasSingleProvider is true an implicit host is parsed from RepositoryUrl.
+
+      Example of SourceLinkGiteeHost items:
+
+      <ItemGroup>
+        <SourceLinkGiteeHost Include="gitee.com" ContentUrl="https://gitee.com"/>
+        <SourceLinkGiteeHost Include="mygitee1.com" />           ContentUrl defaults to https://mygitee1.com/
+        <SourceLinkGiteeHost Include="mygitee2.com:8080" />      ContentUrl defaults to https://mygitee2.com:8080/
+      </ItemGroup>
+
+      ContentUrl is optional. If not specified it defaults to "https://{domain}".
+    -->
+    <Microsoft.SourceLink.Gitee.GetSourceLinkUrl RepositoryUrl="$(PrivateRepositoryUrl)" SourceRoot="@(SourceRoot)" Hosts="@(SourceLinkGiteeHost)" IsSingleProvider="$(SourceLinkHasSingleProvider)">
+      <Output TaskParameter="SourceLinkUrl" PropertyName="_SourceLinkUrlToUpdate"/>
+    </Microsoft.SourceLink.Gitee.GetSourceLinkUrl>
+
+    <ItemGroup>
+      <!-- Only update the SourceLinkUrl metadata if the SourceRoot belongs to this source control -->
+      <SourceRoot Update="%(Identity)" SourceLinkUrl="$(_SourceLinkUrlToUpdate)" Condition="'$(_SourceLinkUrlToUpdate)' != 'N/A'"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- 
+    We need to translate ssh URLs to https.
+  -->
+  <Target Name="TranslateGiteeUrlsInSourceControlInformation">
+
+    <ItemGroup>
+      <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
+    </ItemGroup>
+
+    <Microsoft.SourceLink.Gitee.TranslateRepositoryUrls RepositoryUrl="$(ScmRepositoryUrl)" SourceRoots="@(SourceRoot)" Hosts="@(SourceLinkGiteeHost)" IsSingleProvider="$(SourceLinkHasSingleProvider)">
+      <Output TaskParameter="TranslatedRepositoryUrl" PropertyName="ScmRepositoryUrl"/>
+      <Output TaskParameter="TranslatedSourceRoots" ItemName="_TranslatedSourceRoot"/>
+    </Microsoft.SourceLink.Gitee.TranslateRepositoryUrls>
+
+    <ItemGroup>
+      <SourceRoot Remove="@(SourceRoot)"/>
+      <SourceRoot Include="@(_TranslatedSourceRoot)"/>
+    </ItemGroup>
+  
+</Target>
+
+</Project>

--- a/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.targets
+++ b/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.targets
@@ -6,8 +6,8 @@
     <_SourceLinkGiteeAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.Gitee.dll</_SourceLinkGiteeAssemblyFile>
   </PropertyGroup>
 
-  <UsingTask TaskName="Microsoft.SourceLink.Gitee.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkGitHubAssemblyFile)"/>
-  <UsingTask TaskName="Microsoft.SourceLink.Gitee.TranslateRepositoryUrls" AssemblyFile="$(_SourceLinkGitHubAssemblyFile)"/>
+  <UsingTask TaskName="Microsoft.SourceLink.Gitee.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkGiteeAssemblyFile)"/>
+  <UsingTask TaskName="Microsoft.SourceLink.Gitee.TranslateRepositoryUrls" AssemblyFile="$(_SourceLinkGiteeAssemblyFile)"/>
 
   <PropertyGroup>
     <SourceLinkUrlInitializerTargets>$(SourceLinkUrlInitializerTargets);_InitializeGiteeSourceLinkUrl</SourceLinkUrlInitializerTargets>

--- a/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.props
+++ b/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.props
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project>
+  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+</Project>

--- a/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.targets
+++ b/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.targets
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project>
+  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+</Project>

--- a/src/SourceLink.Gitee/xlf/Resources.cs.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.cs.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.de.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.de.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.es.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.es.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.fr.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.fr.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.it.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.it.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.ja.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.ja.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.ko.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.ko.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.pl.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.pl.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.pt-BR.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.pt-BR.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.ru.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.ru.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.tr.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.tr.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.zh-Hans.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.zh-Hans.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>

--- a/src/SourceLink.Gitee/xlf/Resources.zh-Hant.xlf
+++ b/src/SourceLink.Gitee/xlf/Resources.zh-Hant.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
+    <body />
+  </file>
+</xliff>


### PR DESCRIPTION
Add support for Gitee source control

1. ContentUrl defaults to https://gitee.com
2. Source link url pattern is https://gitee.com/{organization}/{repository}/raw/{revisionId}/*