### PR TITLE
Add System.CommandLine dependencies to Version Details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22272.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>209b724a3c843253d3071e8348c353b297b0b8b5</Sha>
+    </Dependency>
+    <Dependency Name="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>209b724a3c843253d3071e8348c353b297b0b8b5</Sha>
+    </Dependency>
+    <Dependency Name="System.CommandLine.Rendering" Version="0.4.0-alpha.22272.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>209b724a3c843253d3071e8348c353b297b0b8b5</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.22630.1">


### PR DESCRIPTION
This is so that we can enable PVP flow for sourcelink. System.CommandLine should be taken from the previously source built artifacts.