### PR TITLE
Do not report warnings when SourceLink packages are not referenced ex…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 .vs/
+.vscode/
 
 # Build results
 artifacts/

--- a/src/Common/GetSourceLinkUrlGitTask.cs
+++ b/src/Common/GetSourceLinkUrlGitTask.cs
@@ -85,7 +85,15 @@ namespace Microsoft.Build.Tasks.SourceControl
             if (string.IsNullOrEmpty(gitUrl))
             {
                 SourceLinkUrl = NotApplicableValue;
-                Log.LogWarning(CommonResources.UnableToDetermineRepositoryUrl);
+
+                // If SourceRoot has commit sha but not repository URL the source control info is available,
+                // but the remote for the repo has not been defined yet. We already reported missing remote in that case
+                // (unless suppressed).
+                if (string.IsNullOrEmpty(SourceRoot.GetMetadata(Names.SourceRoot.RevisionId)))
+                {
+                    Log.LogWarning(CommonResources.UnableToDetermineRepositoryUrl);
+                }
+
                 return;
             }
 

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
@@ -54,7 +54,7 @@ url=https://github.com/test-org/test-sub
             Assert.Equal("1111111111111111111111111111111111111111", repository.GetHeadCommitSha());
 
             var warnings = new List<(string, object?[])>();
-            var sourceRoots = GitOperations.GetSourceRoots(repository, remoteName: null, (message, args) => warnings.Add((message, args)));
+            var sourceRoots = GitOperations.GetSourceRoots(repository, remoteName: null, warnOnMissingCommit: true, (message, args) => warnings.Add((message, args)));
             AssertEx.Equal(new[]
             {
                 $@"'{repoDir.Path}{s}' SourceControl='git' RevisionId='1111111111111111111111111111111111111111' ScmRepositoryUrl='http://github.com/test-org/test-repo'",

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
@@ -448,16 +448,53 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             Assert.Equal("A.com", actualMappedUrl);
         }
 
-        [Fact]
-        public void GetSourceRoots_RepoWithoutCommits()
+        [Theory]
+        [CombinatorialData]
+        public void GetSourceRoots_RepoWithoutCommits(bool warnOnMissingCommit)
         {
             var repo = CreateRepository();
 
             var warnings = new List<(string, object?[])>();
-            var items = GitOperations.GetSourceRoots(repo, remoteName: null, (message, args) => warnings.Add((message, args)));
+            var items = GitOperations.GetSourceRoots(repo, remoteName: null, warnOnMissingCommit, (message, args) => warnings.Add((message, args)));
 
             Assert.Empty(items);
-            AssertEx.Equal(new[] { Resources.RepositoryHasNoCommit }, warnings.Select(TestUtilities.InspectDiagnostic));
+            AssertEx.Equal(warnOnMissingCommit ? new[] { Resources.RepositoryHasNoCommit } : Array.Empty<string>(), warnings.Select(TestUtilities.InspectDiagnostic));
+        }
+
+        [Fact]
+        public void GetSourceRoots_RepoWithCommits_WithoutUrl()
+        {
+            var repo = CreateRepository(
+                commitSha: "0000000000000000000000000000000000000000");
+
+            var warnings = new List<(string, object?[])>();
+            var items = GitOperations.GetSourceRoots(repo, remoteName: null, warnOnMissingCommit: true, (message, args) => warnings.Add((message, args)));
+
+            AssertEx.Equal(new[]
+            {
+                @"'C:\src\' SourceControl='git' RevisionId='0000000000000000000000000000000000000000'",
+            }, items.Select(TestUtilities.InspectSourceRoot));
+
+            Assert.Empty(warnings.Select(TestUtilities.InspectDiagnostic));
+        }
+
+        [Fact]
+        public void GetSourceRoots_RepoWithCommits_WithUrl()
+        {
+            var repo = CreateRepository(
+                commitSha: "0000000000000000000000000000000000000000",
+                config: CreateConfig(
+                    ("remote.origin.url", "http://github.com/abc")));
+
+            var warnings = new List<(string, object?[])>();
+            var items = GitOperations.GetSourceRoots(repo, remoteName: null, warnOnMissingCommit: true, (message, args) => warnings.Add((message, args)));
+
+            AssertEx.Equal(new[]
+            {
+                @"'C:\src\' SourceControl='git' RevisionId='0000000000000000000000000000000000000000' ScmRepositoryUrl='http://github.com/abc'",
+            }, items.Select(TestUtilities.InspectSourceRoot));
+
+            Assert.Empty(warnings.Select(TestUtilities.InspectDiagnostic));
         }
 
         [Fact]
@@ -480,7 +517,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     CreateSubmodule("sub6", "sub/6", "", "6666666666666666666666666666666666666666")));
 
             var warnings = new List<(string, object?[])>();
-            var items = GitOperations.GetSourceRoots(repo, remoteName: null, (message, args) => warnings.Add((message, args)));
+            var items = GitOperations.GetSourceRoots(repo, remoteName: null, warnOnMissingCommit: false, (message, args) => warnings.Add((message, args)));
 
             // Module without a configuration entry is not initialized.
             // URLs listed in .submodules are ignored (they are used by git submodule initialize to generate URLs stored in config).
@@ -493,9 +530,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
 
             AssertEx.Equal(new[]
             {
-                Resources.RepositoryHasNoCommit,
                 string.Format(Resources.SourceCodeWontBeAvailableViaSourceLink, string.Format(Resources.InvalidSubmoduleUrl, "sub4", "https:///"))
-            }, warnings.Select(TestUtilities.InspectDiagnostic)); ;
+            }, warnings.Select(TestUtilities.InspectDiagnostic));
         }
 
         [Fact]
@@ -511,7 +547,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     CreateSubmodule("2", "sub/2", "http://2.com", "2222222222222222222222222222222222222222")));
 
             var warnings = new List<(string, object?[])>();
-            var items = GitOperations.GetSourceRoots(repo, remoteName: null, (message, args) => warnings.Add((message, args)));
+            var items = GitOperations.GetSourceRoots(repo, remoteName: null, warnOnMissingCommit: false, (message, args) => warnings.Add((message, args)));
 
             AssertEx.Equal(new[]
             {
@@ -547,7 +583,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                     CreateSubmodule("1", "sub/1", "---", "1111111111111111111111111111111111111111", containingRepositoryWorkingDir: repoDir.Path)));
 
             var warnings = new List<(string, object?[])>();
-            var items = GitOperations.GetSourceRoots(repo, remoteName: null, (message, args) => warnings.Add((message, args)));
+            var items = GitOperations.GetSourceRoots(repo, remoteName: null, warnOnMissingCommit: false, (message, args) => warnings.Add((message, args)));
 
             AssertEx.Equal(new[]
             {

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
 
             AssertEx.Equal(new[]
             {
-                @"'C:\src\' SourceControl='git' RevisionId='0000000000000000000000000000000000000000'",
+                $@"'{_workingDir}{s}' SourceControl='git' RevisionId='0000000000000000000000000000000000000000'",
             }, items.Select(TestUtilities.InspectSourceRoot));
 
             Assert.Empty(warnings.Select(TestUtilities.InspectDiagnostic));
@@ -491,7 +491,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
 
             AssertEx.Equal(new[]
             {
-                @"'C:\src\' SourceControl='git' RevisionId='0000000000000000000000000000000000000000' ScmRepositoryUrl='http://github.com/abc'",
+                $@"'{_workingDir}{s}' SourceControl='git' RevisionId='0000000000000000000000000000000000000000' ScmRepositoryUrl='http://github.com/abc'",
             }, items.Select(TestUtilities.InspectSourceRoot));
 
             Assert.Empty(warnings.Select(TestUtilities.InspectDiagnostic));

--- a/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Build.Tasks.Git
             
             RepositoryId = repository.GitDirectory;
             WorkingDirectory = repository.WorkingDirectory;
-            Url = GitOperations.GetRepositoryUrl(repository, RemoteName, Log.LogWarning);
-            Roots = GitOperations.GetSourceRoots(repository, RemoteName, Log.LogWarning);
+            Url = GitOperations.GetRepositoryUrl(repository, RemoteName, warnOnMissingRemote: !NoWarnOnMissingInfo, Log.LogWarning);
+            Roots = GitOperations.GetSourceRoots(repository, RemoteName, warnOnMissingCommit: !NoWarnOnMissingInfo, Log.LogWarning);
             RevisionId = repository.GetHeadCommitSha();
         }
     }

--- a/src/Microsoft.Build.Tasks.Git/RepositoryTask.cs
+++ b/src/Microsoft.Build.Tasks.Git/RepositoryTask.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Build.Tasks.Git
 #endif
 
         /// <summary>
-        /// True to report a warning when the repository can't be located.
+        /// True to report a warning when the repository can't be located, it's missing remote or a commit.
         /// </summary>
-        public bool NoWarnOnMissingRepository { get; set; }
+        public bool NoWarnOnMissingInfo { get; set; }
 
         public sealed override bool Execute()
         {
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Tasks.Git
 
         private void ReportMissingRepositoryWarning(string initialPath)
         {
-            if (!NoWarnOnMissingRepository)
+            if (!NoWarnOnMissingInfo)
             {
                 Log.LogWarning(Resources.UnableToLocateRepository, initialPath);
             }

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -27,7 +27,7 @@
       Path="$(MSBuildProjectDirectory)"
       RemoteName="$(GitRepositoryRemoteName)"
       ConfigurationScope="$(GitRepositoryConfigurationScope)"
-      NoWarnOnMissingRepository="$(PkgMicrosoft_Build_Tasks_Git.Equals(''))">
+      NoWarnOnMissingInfo="$(PkgMicrosoft_Build_Tasks_Git.Equals(''))">
 
       <Output TaskParameter="RepositoryId" PropertyName="_GitRepositoryId" />
       <Output TaskParameter="Url" PropertyName="ScmRepositoryUrl" />

--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -33,9 +33,11 @@ namespace Microsoft.SourceLink.Common.UnitTests
 
             Assert.True(task.Execute());
 
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                noWarning ? "" : "WARNING : " + string.Format(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty),
-                engine.Log);
+            var expectedOutput = 
+                (noWarning ? "" : "WARNING : " + string.Format(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty) + Environment.NewLine) +
+                string.Format(Resources.SourceLinkEmptyNoExistingFile, sourceLinkFilePath);
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedOutput, engine.Log);
 
             Assert.Null(task.SourceLink);
             Assert.Null(task.FileWrite);
@@ -64,9 +66,11 @@ namespace Microsoft.SourceLink.Common.UnitTests
 
             Assert.True(task.Execute());
 
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                noWarning ? "" : "WARNING : " + string.Format(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty),
-                engine.Log);
+            var expectedOutput = 
+                (noWarning ? "" : "WARNING : " + string.Format(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty) + Environment.NewLine) +
+                string.Format(Resources.SourceLinkEmptyNoExistingFile, sourceLinkFilePath);
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedOutput, engine.Log);
 
             Assert.Null(task.SourceLink);
             Assert.Null(task.FileWrite);
@@ -92,7 +96,8 @@ namespace Microsoft.SourceLink.Common.UnitTests
 
             Assert.True(task.Execute());
 
-            AssertEx.AssertEqualToleratingWhitespaceDifferences("", engine.Log);
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                string.Format(Resources.SourceLinkEmptyDeletingExistingFile, sourceLinkFile.Path), engine.Log);
 
             Assert.Null(task.SourceLink);
             Assert.Equal(sourceLinkFile.Path, task.FileWrite);

--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -57,9 +57,9 @@ namespace Microsoft.SourceLink.Common.UnitTests
                 OutputFile = sourceLinkFilePath,
                 SourceRoots = new[]
                 {
-                    new MockItem(@"C:\src1\", KVP("MappedPath", @"C:\src1\")),
-                    new MockItem(@"C:\src2\", KVP("MappedPath", @"C:\src2\"), KVP("RevisionId", "f3dbcdfdd5b1f75613c7692f969d8df121fc3731"), KVP("SourceControl", "git")),
-                    new MockItem(@"C:\src3\", KVP("MappedPath", @"C:\src3\"), KVP("RevisionId", "f3dbcdfdd5b1f75613c7692f969d8df121fc3731"), KVP("SourceControl", "git"), KVP("RepositoryUrl", "")),
+                    new MockItem("/1/", KVP("MappedPath", "/1/")),
+                    new MockItem("/2/", KVP("MappedPath", "/2/"), KVP("RevisionId", "f3dbcdfdd5b1f75613c7692f969d8df121fc3731"), KVP("SourceControl", "git")),
+                    new MockItem("/3/", KVP("MappedPath", "/3/"), KVP("RevisionId", "f3dbcdfdd5b1f75613c7692f969d8df121fc3731"), KVP("SourceControl", "git"), KVP("RepositoryUrl", "")),
                 },
                 NoWarnOnMissingSourceControlInformation = noWarning,
             };

--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -41,6 +41,37 @@ namespace Microsoft.SourceLink.Common.UnitTests
             Assert.Null(task.FileWrite);
         }
 
+        [Theory]
+        [CombinatorialData]
+        public void NoRepositoryUrl(bool noWarning)
+        {
+            var sourceLinkFilePath = Path.Combine(TempRoot.Root, Guid.NewGuid().ToString());
+
+            var engine = new MockEngine();
+
+            var task = new GenerateSourceLinkFile()
+            {
+                BuildEngine = engine,
+                OutputFile = sourceLinkFilePath,
+                SourceRoots = new[]
+                {
+                    new MockItem(@"C:\src1\", KVP("MappedPath", @"C:\src1\")),
+                    new MockItem(@"C:\src2\", KVP("MappedPath", @"C:\src2\"), KVP("RevisionId", "f3dbcdfdd5b1f75613c7692f969d8df121fc3731"), KVP("SourceControl", "git")),
+                    new MockItem(@"C:\src3\", KVP("MappedPath", @"C:\src3\"), KVP("RevisionId", "f3dbcdfdd5b1f75613c7692f969d8df121fc3731"), KVP("SourceControl", "git"), KVP("RepositoryUrl", "")),
+                },
+                NoWarnOnMissingSourceControlInformation = noWarning,
+            };
+
+            Assert.True(task.Execute());
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                noWarning ? "" : "WARNING : " + string.Format(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty),
+                engine.Log);
+
+            Assert.Null(task.SourceLink);
+            Assert.Null(task.FileWrite);
+        }
+
         [Fact]
         public void Empty_DeleteExistingFile()
         {

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -124,6 +124,8 @@ namespace Microsoft.SourceLink.Common
                 {
                     if (content == null)
                     {
+                        Log.LogMessage(Resources.SourceLinkEmptyDeletingExistingFile, OutputFile);
+
                         File.Delete(OutputFile);
                         FileWrite = OutputFile;
                         return;
@@ -133,6 +135,8 @@ namespace Microsoft.SourceLink.Common
                     if (originalContent == content)
                     {
                         // Don't rewrite the file if the contents is the same, just pass it to the compiler.
+                        Log.LogMessage(Resources.SourceLinkFileUpToDate, OutputFile);
+
                         SourceLink = OutputFile;
                         return;
                     }
@@ -141,9 +145,11 @@ namespace Microsoft.SourceLink.Common
                 {
                     // File doesn't exist and the output is empty:
                     // Do not write the file and don't pass it to the compiler.
+                    Log.LogMessage(Resources.SourceLinkEmptyNoExistingFile, OutputFile);
                     return;
                 }
 
+                Log.LogMessage(Resources.SourceLinkFileUpdated, OutputFile);
                 File.WriteAllText(OutputFile, content);
                 FileWrite = SourceLink = OutputFile;
             }

--- a/src/SourceLink.Common/Resources.resx
+++ b/src/SourceLink.Common/Resources.resx
@@ -129,6 +129,18 @@
   <data name="SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty" xml:space="preserve">
     <value>Source control information is not available - the generated source link is empty.</value>
   </data>
+  <data name="SourceLinkEmptyDeletingExistingFile" xml:space="preserve">
+    <value>Source Link is empty, deleting existing file: '{0}'.</value>
+  </data>
+  <data name="SourceLinkEmptyNoExistingFile" xml:space="preserve">
+    <value>Source Link is empty, file '{0}' does not exist.</value>
+  </data>
+  <data name="SourceLinkFileUpToDate" xml:space="preserve">
+    <value>Source Link file '{0}' is up-to-date.</value>
+  </data>
+  <data name="SourceLinkFileUpdated" xml:space="preserve">
+    <value>Updating Source Link file '{0}'.</value>
+  </data>
   <data name="IsEmpty" xml:space="preserve">
     <value>{0} is empty: '{1}'</value>
   </data>

--- a/src/SourceLink.Common/xlf/Resources.cs.xlf
+++ b/src/SourceLink.Common/xlf/Resources.cs.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Informace o řízení zdrojů nejsou k dispozici - vygenerovaný odkaz na zdroj je prázdný.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.de.xlf
+++ b/src/SourceLink.Common/xlf/Resources.de.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Es sind keine Informationen zur Quellcodeverwaltung verfügbar. Die generierte Quellverknüpfung ist leer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.es.xlf
+++ b/src/SourceLink.Common/xlf/Resources.es.xlf
@@ -32,6 +32,26 @@
         <target state="translated">La información de control del código fuente no está disponible: el vínculo de origen generado está vacío.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.fr.xlf
+++ b/src/SourceLink.Common/xlf/Resources.fr.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Les informations de contrôle de code source ne sont pas disponibles - le lien source généré est vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.it.xlf
+++ b/src/SourceLink.Common/xlf/Resources.it.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Le informazioni sul controllo del codice sorgente non sono disponibili. Il collegamento all'origine generato è vuoto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.ja.xlf
+++ b/src/SourceLink.Common/xlf/Resources.ja.xlf
@@ -32,6 +32,26 @@
         <target state="translated">ソース コントロール情報は利用できません。 生成されたソース リンクが空です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.ko.xlf
+++ b/src/SourceLink.Common/xlf/Resources.ko.xlf
@@ -32,6 +32,26 @@
         <target state="translated">소스 제어 정보를 사용할 수 없습니다. 생성된 소스 링크가 비어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.pl.xlf
+++ b/src/SourceLink.Common/xlf/Resources.pl.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Informacje o kontroli źródła są niedostępne — wygenerowany link do źródła jest pusty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.pt-BR.xlf
+++ b/src/SourceLink.Common/xlf/Resources.pt-BR.xlf
@@ -32,6 +32,26 @@
         <target state="translated">As informações de controle de origem não estão disponíveis – o source link origem gerado está vazio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.ru.xlf
+++ b/src/SourceLink.Common/xlf/Resources.ru.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Информация о системе управления версиями недоступна — созданная исходная ссылка является пустой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.tr.xlf
+++ b/src/SourceLink.Common/xlf/Resources.tr.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Kaynak denetimi bilgileri kullanılamıyor. Oluşturulan kaynak bağlantısı boş.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.zh-Hans.xlf
+++ b/src/SourceLink.Common/xlf/Resources.zh-Hans.xlf
@@ -32,6 +32,26 @@
         <target state="translated">源代码管理信息不可用 - 生成的源链接为空。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Common/xlf/Resources.zh-Hant.xlf
+++ b/src/SourceLink.Common/xlf/Resources.zh-Hant.xlf
@@ -32,6 +32,26 @@
         <target state="translated">無法取得原始檔控制資訊 - 產生的來源連結是空的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceLinkEmptyDeletingExistingFile">
+        <source>Source Link is empty, deleting existing file: '{0}'.</source>
+        <target state="new">Source Link is empty, deleting existing file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkEmptyNoExistingFile">
+        <source>Source Link is empty, file '{0}' does not exist.</source>
+        <target state="new">Source Link is empty, file '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpToDate">
+        <source>Source Link file '{0}' is up-to-date.</source>
+        <target state="new">Source Link file '{0}' is up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceLinkFileUpdated">
+        <source>Updating Source Link file '{0}'.</source>
+        <target state="new">Updating Source Link file '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/SourceLink.Git.IntegrationTests/AzureDevOpsServerTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/AzureDevOpsServerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://tfs.噸.local:8080/tfs/DefaultCollection/project/_git/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -80,7 +80,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "ssh://tfs.噸.local:22/tfs/DefaultCollection/project/_ssh/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/AzureReposTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/AzureReposTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = $"https://test.{host}/test-org/_git/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -82,7 +82,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = $"ssh://test@vs-ssh.{host}:22/test-org/_ssh/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://test-user@bitbucket.org/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -76,7 +76,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://bitbucket.domain.com/scm/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] {ProjectFileName},
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] {ProjectFileName},
                 repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
@@ -133,7 +133,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://user_name%40domain.com:Bitbucket_personaltoken@bitbucket.domain.com/scm/test-org/project1.git";
             var repoName = "project1";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName },
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName },
                 repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
@@ -192,7 +192,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://bitbucket.domain.com/scm/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName },
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName },
                 repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
@@ -251,7 +251,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://bitbucket.domain.com/scm/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -309,7 +309,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -367,7 +367,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -425,7 +425,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
@@ -17,39 +17,6 @@ namespace Microsoft.SourceLink.IntegrationTests
         }
 
         [ConditionalFact(typeof(DotNetSdkAvailable))]
-        public void EmptyRepository()
-        {
-            Repository.Init(workingDirectoryPath: ProjectDir.Path, gitDirectoryPath: Path.Combine(ProjectDir.Path, ".git"));
-
-            VerifyValues(
-                customProps:  "",
-                customTargets: "",
-                targets: new[]
-                {
-                    "Build"
-                },
-                expressions: new[] 
-                {
-                    "@(SourceRoot)",
-                },
-                expectedResults: new[]
-                {
-                    NuGetPackageFolders
-                },
-                expectedWarnings: new[]
-                {
-                    // Repository has no remote.
-                    string.Format(Resources.RepositoryHasNoRemote, ProjectDir.Path),
-
-                    // Repository doesn't have any commit.
-                    string.Format(Resources.RepositoryHasNoCommit, ProjectDir.Path),
-
-                    // No SourceRoot items specified - the generated source link is empty.
-                    string.Format(Common.Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty),
-                });
-        }
-
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void MutlipleProjects()
         {
             var projectName2 = "Project2";
@@ -63,7 +30,7 @@ namespace Microsoft.SourceLink.IntegrationTests
 </Project>
 ");
 
-            using var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(
+            using var repo = GitUtilities.CreateGitRepository(
                 RootDir.Path, 
                 new[] { Path.Combine(ProjectName, ProjectFileName), Path.Combine(projectName2, projectFileName2) },
                 "http://github.com/test-org/test-repo1");
@@ -140,7 +107,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void Environment_Enabled()
         {
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo1");
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo1");
             var commitSha = repo.Head.Tip.Sha;
 
             PrepareTestEnvironment();
@@ -172,7 +139,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void Environment_Disabled()
         {
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo1");
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo1");
             var commitSha = repo.Head.Tip.Sha;
 
             PrepareTestEnvironment();
@@ -213,7 +180,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "http://github.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -269,7 +236,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "ssh://github.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/GitLabTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitLabTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -80,7 +80,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -139,7 +139,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "http://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/GitWebTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitWebTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = $"ssh://git@噸.com/test-%72epo\u1234%24%2572%2F.git";
             var repoName = "test-repo\u1234%24%2572%2F.git";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -78,7 +78,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         public void Issues_error_on_git_url()
         {
             var repoUrl = "git://噸.com/invalid_url_protocol.git";
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -105,7 +105,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         public void Issues_error_on_https_url()
         {
             var repoUrl = "https://噸.com/invalid_url_protocol.git";
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/GiteaTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteaTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -80,7 +80,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -139,7 +139,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "http://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "https://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -80,7 +80,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "test-user@噸.com:test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(
@@ -139,7 +139,7 @@ namespace Microsoft.SourceLink.IntegrationTests
             var repoUrl = "http://噸.com/test-org/test-%72epo\u1234%24%2572%2F";
             var repoName = "test-repo\u1234%24%2572%2F";
 
-            var repo = GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
+            var repo = GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, repoUrl);
             var commitSha = repo.Head.Tip.Sha;
 
             VerifyValues(

--- a/src/SourceLink.Git.IntegrationTests/TargetTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/TargetTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void GenerateSourceLinkFileTarget_EnableSourceLinkCondition()
         {
-            GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo");
+            GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo");
 
             VerifyValues(
                 customProps: @"
@@ -65,7 +65,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void DefaultValuesForEnableProperties_DesignTimeBuild()
         {
-            GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo");
+            GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo");
 
             VerifyValues(
                 customProps: @"
@@ -100,7 +100,7 @@ namespace Microsoft.SourceLink.IntegrationTests
         [ConditionalFact(typeof(DotNetSdkAvailable))]
         public void DefaultValuesForEnableProperties_BuildingForLiveUnitTesting()
         {
-            GitUtilities.CreateGitRepositoryWithSingleCommit(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo");
+            GitUtilities.CreateGitRepository(ProjectDir.Path, new[] { ProjectFileName }, "http://github.com/test-org/test-repo");
 
             VerifyValues(
                 customProps: @"

--- a/src/SourceLink.Git.IntegrationTests/Utilities/GitUtilities.cs
+++ b/src/SourceLink.Git.IntegrationTests/Utilities/GitUtilities.cs
@@ -12,18 +12,25 @@ namespace Microsoft.SourceLink.IntegrationTests
     {
         private static readonly Signature s_signature = new Signature("test", "test@test.com", DateTimeOffset.Now);
 
-        public static Repository CreateGitRepositoryWithSingleCommit(string directory, string[] commitFileNames, string originUrl)
+        public static Repository CreateGitRepository(string directory, string[]? commitFileNames, string? originUrl)
         {
             var repository = new Repository(Repository.Init(workingDirectoryPath: directory, gitDirectoryPath: Path.Combine(directory, ".git")));
-            repository.Network.Remotes.Add("origin", originUrl);
 
-            foreach (var fileName in commitFileNames)
+            if (originUrl != null)
             {
-                repository.Index.Add(fileName);
+                repository.Network.Remotes.Add("origin", originUrl);
             }
 
-            repository.Index.Write();
-            repository.Commit("First commit", s_signature, s_signature);
+            if (commitFileNames != null)
+            {
+                foreach (var fileName in commitFileNames)
+                {
+                    repository.Index.Add(fileName);
+                }
+
+                repository.Index.Write();
+                repository.Commit("First commit", s_signature, s_signature);
+            }
 
             return repository;
         }


### PR DESCRIPTION
…plicitly and the repository has no URL or no commit.

This allows the user to build an app in a new local repo, without having to set origin remote or commit changes first.