### PR TITLE
Bump version to 8.0 to match SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,8 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
-    <SemanticVersioningV1>true</SemanticVersioningV1>
     <!-- Opt-in repo features -->
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>


### PR DESCRIPTION
Going forward Source Link will follow .NET SDK versioning since it's bundled with it.

See https://github.com/dotnet/sdk/pull/31632