### PR TITLE
Fix FileWrites

### DIFF
--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -40,7 +40,6 @@ namespace Microsoft.SourceLink.Common.UnitTests
             AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedOutput, engine.Log);
 
             Assert.Null(task.SourceLink);
-            Assert.Null(task.FileWrite);
         }
 
         [Theory]
@@ -73,7 +72,6 @@ namespace Microsoft.SourceLink.Common.UnitTests
             AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedOutput, engine.Log);
 
             Assert.Null(task.SourceLink);
-            Assert.Null(task.FileWrite);
         }
 
         [Fact]
@@ -100,7 +98,6 @@ namespace Microsoft.SourceLink.Common.UnitTests
                 string.Format(Resources.SourceLinkEmptyDeletingExistingFile, sourceLinkFile.Path), engine.Log);
 
             Assert.Null(task.SourceLink);
-            Assert.Equal(sourceLinkFile.Path, task.FileWrite);
         }
 
         [Fact]
@@ -235,7 +232,6 @@ namespace Microsoft.SourceLink.Common.UnitTests
 
             Assert.Equal(@"{""documents"":{""/_\""_/*"":""https://raw.githubusercontent.com/repo/*""}}", File.ReadAllText(tempFile.Path, Encoding.UTF8));
             Assert.Equal(tempFile.Path, task.SourceLink);
-            Assert.Equal(tempFile.Path, task.FileWrite);
 
             result = task.Execute();
 

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -22,12 +22,6 @@ namespace Microsoft.SourceLink.Common
         public string? OutputFile { get; set; }
 
         /// <summary>
-        /// Set to <see cref="OutputFile"/> if the output file was written to, null otherwise.
-        /// </summary>
-        [Output]
-        public string? FileWrite { get; set; }
-
-        /// <summary>
         /// Set to <see cref="OutputFile"/> if the output Source Link file should be passed to the compiler.
         /// </summary>
         [Output]
@@ -60,14 +54,14 @@ namespace Microsoft.SourceLink.Common
 
                 if (!localPath.EndsWithSeparator())
                 {
-                    Log.LogError(Resources.MustEndWithDirectorySeparator, (isMapped ? Names.SourceRoot.MappedPathFullName : Names.SourceRoot.Name), localPath);
+                    Log.LogError(Resources.MustEndWithDirectorySeparator, isMapped ? Names.SourceRoot.MappedPathFullName : Names.SourceRoot.Name, localPath);
                     success = false;
                     continue;
                 }
 
                 if (localPath.Contains('*'))
                 {
-                    Log.LogError(Resources.MustNotContainWildcard, (isMapped ? Names.SourceRoot.MappedPathFullName : Names.SourceRoot.Name), localPath);
+                    Log.LogError(Resources.MustNotContainWildcard, isMapped ? Names.SourceRoot.MappedPathFullName : Names.SourceRoot.Name, localPath);
                     success = false;
                     continue;
                 }
@@ -127,7 +121,6 @@ namespace Microsoft.SourceLink.Common
                         Log.LogMessage(Resources.SourceLinkEmptyDeletingExistingFile, OutputFile);
 
                         File.Delete(OutputFile);
-                        FileWrite = OutputFile;
                         return;
                     }
 
@@ -151,14 +144,11 @@ namespace Microsoft.SourceLink.Common
 
                 Log.LogMessage(Resources.SourceLinkFileUpdated, OutputFile);
                 File.WriteAllText(OutputFile, content);
-                FileWrite = SourceLink = OutputFile;
+                SourceLink = OutputFile;
             }
             catch (Exception e)
             {
                 Log.LogError(Resources.ErrorWritingToSourceLinkFile, OutputFile, e.Message);
-
-                // Part of the file might have been written.
-                FileWrite = OutputFile;
             }
         }
     }

--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
+++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
@@ -58,10 +58,15 @@
 
       <!-- Set SourceLink property passed to compilers -->
       <Output TaskParameter="SourceLink" PropertyName="SourceLink" />
-
-      <!-- Log file write if the content of the file has been updated -->
-      <Output TaskParameter="FileWrite" ItemName="FileWrites" />
     </Microsoft.SourceLink.Common.GenerateSourceLinkFile>
+
+    <!--
+      Include the output file whenever it exists, even if it hasn't been written to (it was up-to-date).
+      This is needed so that incremental clean doesn't delete the file.
+    -->
+    <ItemGroup Condition="'$(SourceLink)' != ''">
+      <FileWrites Include="$(SourceLink)" />
+    </ItemGroup>
 
     <!-- C++ Link task currently doesn't recognize SourceLink property -->
     <ItemGroup Condition="'$(Language)' == 'C++' and '$(SourceLink)' != ''">

--- a/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
@@ -131,6 +131,11 @@ namespace Microsoft.SourceLink.IntegrationTests
                   <PkgMicrosoft_Build_Tasks_Git></PkgMicrosoft_Build_Tasks_Git>
                   <PkgMicrosoft_SourceLink_Common></PkgMicrosoft_SourceLink_Common>
                 </PropertyGroup>
+                <Target Name="_CaptureFileWrites" DependsOnTargets="GenerateSourceLinkFile" BeforeTargets="AfterBuild">
+                  <ItemGroup>
+                    <_SourceLinkFileWrites Include="@(FileWrites)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').EndsWith('sourcelink.json'))"/>
+                  </ItemGroup>
+                </Target>
                 """,
                 customTargets: "",
                 targets: new[]
@@ -141,10 +146,12 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "$(SourceLink)",
+                    "@(_SourceLinkFileWrites)",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
+                    "",
                     "",
                 });
         }
@@ -160,6 +167,11 @@ namespace Microsoft.SourceLink.IntegrationTests
                   <PkgMicrosoft_Build_Tasks_Git></PkgMicrosoft_Build_Tasks_Git>
                   <PkgMicrosoft_SourceLink_Common></PkgMicrosoft_SourceLink_Common>
                 </PropertyGroup>
+                <Target Name="_CaptureFileWrites" DependsOnTargets="GenerateSourceLinkFile" BeforeTargets="AfterBuild">
+                  <ItemGroup>
+                    <_SourceLinkFileWrites Include="@(FileWrites)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').EndsWith('sourcelink.json'))"/>
+                  </ItemGroup>
+                </Target>
                 """,
                 customTargets: "",
                 targets: new[]
@@ -170,11 +182,13 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "$(SourceLink)",
+                    "@(_SourceLinkFileWrites)",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
+                    "",
                     "",
                 });
         }
@@ -190,6 +204,11 @@ namespace Microsoft.SourceLink.IntegrationTests
                   <PkgMicrosoft_Build_Tasks_Git></PkgMicrosoft_Build_Tasks_Git>
                   <PkgMicrosoft_SourceLink_Common></PkgMicrosoft_SourceLink_Common>
                 </PropertyGroup>
+                <Target Name="_CaptureFileWrites" DependsOnTargets="GenerateSourceLinkFile" BeforeTargets="AfterBuild">
+                  <ItemGroup>
+                    <_SourceLinkFileWrites Include="@(FileWrites)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').EndsWith('sourcelink.json'))"/>
+                  </ItemGroup>
+                </Target>
                 """,
                 customTargets: "",
                 targets: new[]
@@ -200,10 +219,12 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "$(SourceLink)",
+                    "@(_SourceLinkFileWrites)",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
+                    "",
                     "",
                 });
         }
@@ -230,21 +251,27 @@ namespace Microsoft.SourceLink.IntegrationTests
         DependsOnTargets=""$(SourceControlManagerUrlTranslationTargets)""
         BeforeTargets=""SourceControlManagerPublishTranslatedUrls"">
 
-    <PropertyGroup>
-      <_Pattern>https://([^.]+)[.]visualstudio.com/([^/]+)/_git/([^/]+)</_Pattern>
-      <_Replacement>https://github.com/$2/$3</_Replacement>
-    </PropertyGroup>
+  <PropertyGroup>
+    <_Pattern>https://([^.]+)[.]visualstudio.com/([^/]+)/_git/([^/]+)</_Pattern>
+    <_Replacement>https://github.com/$2/$3</_Replacement>
+  </PropertyGroup>
 
-    <PropertyGroup>
-      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_Pattern), $(_Replacement)))</ScmRepositoryUrl>
-    </PropertyGroup>
+  <PropertyGroup>
+    <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_Pattern), $(_Replacement)))</ScmRepositoryUrl>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <SourceRoot Update=""@(SourceRoot)"">
-        <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_Pattern), $(_Replacement)))</ScmRepositoryUrl>
-      </SourceRoot>
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <SourceRoot Update=""@(SourceRoot)"">
+      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_Pattern), $(_Replacement)))</ScmRepositoryUrl>
+    </SourceRoot>
+  </ItemGroup>
+</Target>
+
+<Target Name=""_CaptureFileWrites"" DependsOnTargets=""GenerateSourceLinkFile"" BeforeTargets=""AfterBuild"">
+  <ItemGroup>
+    <_SourceLinkFileWrites Include=""@(FileWrites)"" Condition=""$([MSBuild]::ValueOrDefault('%(Identity)', '').EndsWith('sourcelink.json'))""/>
+  </ItemGroup>
+</Target>
 ",
                 targets: new[]
                 {
@@ -256,7 +283,8 @@ namespace Microsoft.SourceLink.IntegrationTests
                     "@(SourceRoot->'%(SourceLinkUrl)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
-                    "$(RepositoryUrl)"
+                    "$(RepositoryUrl)",
+                    "@(_SourceLinkFileWrites)",
                 },
                 expectedResults: new[]
                 {
@@ -266,6 +294,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     s_relativeSourceLinkJsonPath,
                     $"https://github.com/test-org/{repoName}",
                     $"https://github.com/test-org/{repoName}",
+                    s_relativeSourceLinkJsonPath
                 });
 
             AssertEx.AreEqual(


### PR DESCRIPTION
Need to add Source Link path to FIleWrites even if we do not actually write to the file, for incremental clean targets to work properly.

Fixes https://github.com/dotnet/sourcelink/issues/993