### PR TITLE
Clean-up sourcelink repo and remove workarounds

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
-   <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
-   </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+
 </Project>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,18 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>
+﻿<Project>
 
   <PropertyGroup>
     <GitHubRepositoryName>sourcelink</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
     <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
-
-  <Target Name="GetRepoSourceBuildCommandConfiguration"
-          BeforeTargets="GetSourceBuildCommandConfiguration">
-    <PropertyGroup>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:Pack=true</InnerBuildArgs>
-    </PropertyGroup>
-  </Target>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,25 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <!-- This repo version -->
     <VersionPrefix>8.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
+    <!-- msbuild -->
     <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
-    <MicrosoftBuildTasksCore>17.3.2</MicrosoftBuildTasksCore>
-    <!-- TODO: Remove after https://github.com/dotnet/arcade/pull/13178 is consumed. -->
-    <MicrosoftNETTestSdkVersion>17.5.0</MicrosoftNETTestSdkVersion>
-    <MicrosoftTeamFoundationServerExtendedClientVersion>19.210.0-preview</MicrosoftTeamFoundationServerExtendedClientVersion>
+    <MicrosoftBuildTasksCoreVersion>17.3.2</MicrosoftBuildTasksCoreVersion>
+    <!-- nuget -->
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
-    <NuGetPackagingVersion>5.7.0</NuGetPackagingVersion>
+    <!-- commandline -->
     <SystemCommandLineVersion>2.0.0-beta4.22272.1</SystemCommandLineVersion>
     <SystemCommandLineNamingConventionBinderVersion>2.0.0-beta4.22272.1</SystemCommandLineNamingConventionBinderVersion>
     <SystemCommandLineRenderingVersion>0.4.0-alpha.22272.1</SystemCommandLineRenderingVersion>
+    <!-- runtime-->
     <SystemTextJsonVersion>7.0.2</SystemTextJsonVersion>
-    <XunitCombinatorialVersion>1.5.25</XunitCombinatorialVersion>
+    <!-- external -->
+    <MicrosoftTeamFoundationServerExtendedClientVersion>19.210.0-preview</MicrosoftTeamFoundationServerExtendedClientVersion>
     <!-- libgit2 used for integration tests -->
     <LibGit2SharpVersion>0.27.0-preview-0119</LibGit2SharpVersion>
+    <XunitCombinatorialVersion>1.5.25</XunitCombinatorialVersion>
   </PropertyGroup>
+
 </Project>

--- a/eng/runtimeconfig.template.json
+++ b/eng/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-  "rollForwardOnNoCandidateFx": 2
-} 

--- a/global.json
+++ b/global.json
@@ -3,6 +3,7 @@
     "dotnet": "8.0.100-preview.3.23178.7"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23217.1"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23217.1",
+    "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>
+﻿<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
@@ -8,7 +6,6 @@
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateResxSource>true</GenerateResxSource>
-    <UserRuntimeConfig Condition="$(TargetFramework.StartsWith('netcoreapp'))">$(RepositoryEngineeringDir)runtimeconfig.template.json</UserRuntimeConfig>
     
     <!-- Produce snupkg in official builds (when not embedding PDBs to dlls) -->
     <IncludeSymbols Condition="'$(DebugType)' != 'embedded'">true</IncludeSymbols>
@@ -21,4 +18,5 @@
   <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>
+﻿<Project>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- TODO: Remove when Arcade offers an in-built way to filter out anything other than NetCurrent. -->
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' != '' and '$(DotNetBuildFromSource)' == 'true'">$(NetCurrent)</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- Upgrade the NETStandard.Library transitive xunit dependency to avoid transitive 1.x NS dependencies. -->
@@ -40,4 +44,5 @@
       <PackageId Condition="'$(PackageId)' == ''">$(MSBuildProjectName)</PackageId>
     </PropertyGroup>
   </Target>
+
 </Project>

--- a/src/Microsoft.Build.StandardCI/Microsoft.Build.StandardCI.csproj
+++ b/src/Microsoft.Build.StandardCI/Microsoft.Build.StandardCI.csproj
@@ -1,32 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-
-    <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
-    <NuspecBasePath>$(OutputPath)</NuspecBasePath>
-
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageDescription>Standard CI targets.</PackageDescription>
     <PackageTags>Standard CI msbuild targets</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IncludeSymbols>false</IncludeSymbols>
+    <!-- This is a content only package. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
+    <None Include="build\Microsoft.Build.StandardCI.props"
+          Pack="true"
+          PackagePath="build" />
   </ItemGroup>
 
-  <!-- Nothing to build, just create packages -->
-  <Target Name="Build">
-    <MakeDir Directories="$(IntermediateOutputPath)" ContinueOnError="True" />
-  </Target>
-
-  <Target Name="Test" />
 </Project>

--- a/src/Microsoft.Build.StandardCI/build/Microsoft.Build.StandardCI.props
+++ b/src/Microsoft.Build.StandardCI/build/Microsoft.Build.StandardCI.props
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <!--
     Default values for properties initialized from Standard CI environment variables.
     See https://github.com/dotnet/sourcelink/tree/master/docs/StandardCI.
@@ -39,4 +39,5 @@
     -->
     <RepositoryType Condition="'$(RepositoryType)' == ''">$(STANDARD_CI_REPOSITORY_TYPE)</RepositoryType>
   </PropertyGroup>
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/Microsoft.Build.Tasks.Git.UnitTests.csproj
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/Microsoft.Build.Tasks.Git.UnitTests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
     <ProjectReference Include="..\Microsoft.Build.Tasks.Git\Microsoft.Build.Tasks.Git.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>

--- a/src/Microsoft.Build.Tasks.Git/Microsoft.Build.Tasks.Git.csproj
+++ b/src/Microsoft.Build.Tasks.Git/Microsoft.Build.Tasks.Git.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- NuGet: Using an explicit nuspec file to customize TFM directory -->
@@ -16,10 +14,12 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
@@ -27,9 +27,11 @@
     <Compile Include="..\Common\PathUtilities.cs" Link="Common\PathUtilities.cs" />
     <Compile Include="..\Common\SequenceComparer.cs" Link="Common\SequenceComparer.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.Git.Operations" />
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.Git.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />
   </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <MicrosoftBuildTasksGitAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.Build.Tasks.Git.dll</MicrosoftBuildTasksGitAssemblyFile>
     <MicrosoftBuildTasksGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.Build.Tasks.Git.dll</MicrosoftBuildTasksGitAssemblyFile>
   </PropertyGroup>
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <UsingTask TaskName="Microsoft.Build.Tasks.Git.LocateRepository" AssemblyFile="$(MicrosoftBuildTasksGitAssemblyFile)"/>
   <UsingTask TaskName="Microsoft.Build.Tasks.Git.GetUntrackedFiles" AssemblyFile="$(MicrosoftBuildTasksGitAssemblyFile)"/>
 
@@ -46,7 +46,6 @@
   -->
   <Target Name="SetEmbeddedFilesFromSourceControlManagerUntrackedFiles"
           DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
-
     <Microsoft.Build.Tasks.Git.GetUntrackedFiles
       RepositoryId="$(_GitRepositoryId)"
       ConfigurationScope="$(GitRepositoryConfigurationScope)"

--- a/src/Microsoft.Build.Tasks.Git/buildMultiTargeting/Microsoft.Build.Tasks.Git.props
+++ b/src/Microsoft.Build.Tasks.Git/buildMultiTargeting/Microsoft.Build.Tasks.Git.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Git/buildMultiTargeting/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/buildMultiTargeting/Microsoft.Build.Tasks.Git.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Tfvc/Microsoft.Build.Tasks.Tfvc.csproj
+++ b/src/Microsoft.Build.Tasks.Tfvc/Microsoft.Build.Tasks.Tfvc.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
 
     <!-- NuGet: Using an explicit nuspec file to customize TFM directory -->
@@ -17,14 +15,17 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(MicrosoftTeamFoundationServerExtendedClientVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\PathUtilities.cs" Link="Common\PathUtilities.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
   </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Tfvc/build/Microsoft.Build.Tasks.Tfvc.props
+++ b/src/Microsoft.Build.Tasks.Tfvc/build/Microsoft.Build.Tasks.Tfvc.props
@@ -1,7 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <MicrosoftBuildTasksTfvcAssemblyFile>$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.Build.Tasks.Tfvc.dll</MicrosoftBuildTasksTfvcAssemblyFile>
   </PropertyGroup>
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Tfvc/build/Microsoft.Build.Tasks.Tfvc.targets
+++ b/src/Microsoft.Build.Tasks.Tfvc/build/Microsoft.Build.Tasks.Tfvc.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <UsingTask TaskName="Microsoft.Build.Tasks.Tfvc.LocateRepository" AssemblyFile="$(MicrosoftBuildTasksTfvcAssemblyFile)"/>
   <UsingTask TaskName="Microsoft.Build.Tasks.Tfvc.GetSourceRoots" AssemblyFile="$(MicrosoftBuildTasksTfvcAssemblyFile)"/>
   <UsingTask TaskName="Microsoft.Build.Tasks.Tfvc.GetRepositoryUrl" AssemblyFile="$(MicrosoftBuildTasksTfvcAssemblyFile)"/>
@@ -41,7 +41,6 @@
   -->
   <Target Name="SetEmbeddedFilesFromSourceControlManagerUntrackedFiles"
           DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
-
     <Microsoft.Build.Tasks.Tfvc.GetUntrackedFiles WorkspaceDirectory="$(_TfvcWorkspaceDirectory)" ProjectDirectory="$(MSBuildProjectDirectory)" Files="@(Compile)">
       <Output TaskParameter="UntrackedFiles" ItemName="EmbeddedFiles" />
     </Microsoft.Build.Tasks.Tfvc.GetUntrackedFiles>

--- a/src/Microsoft.Build.Tasks.Tfvc/buildMultiTargeting/Microsoft.Build.Tasks.Tfvc.props
+++ b/src/Microsoft.Build.Tasks.Tfvc/buildMultiTargeting/Microsoft.Build.Tasks.Tfvc.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/Microsoft.Build.Tasks.Tfvc/buildMultiTargeting/Microsoft.Build.Tasks.Tfvc.targets
+++ b/src/Microsoft.Build.Tasks.Tfvc/buildMultiTargeting/Microsoft.Build.Tasks.Tfvc.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.AzureDevOpsServer.Git.UnitTests/Microsoft.SourceLink.AzureDevOpsServer.Git.UnitTests.csproj
+++ b/src/SourceLink.AzureDevOpsServer.Git.UnitTests/Microsoft.SourceLink.AzureDevOpsServer.Git.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.AzureDevOpsServer.Git\Microsoft.SourceLink.AzureDevOpsServer.Git.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.AzureDevOpsServer.Git/Microsoft.SourceLink.AzureDevOpsServer.Git.csproj
+++ b/src/SourceLink.AzureDevOpsServer.Git/Microsoft.SourceLink.AzureDevOpsServer.Git.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,6 +13,7 @@
     <PackageTags>MSBuild Tasks Azure DepOps Server TFS Git source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
@@ -22,15 +21,20 @@
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
     <Compile Include="..\Common\AzureDevOpsUrlParser.cs" Link="Common\AzureDevOpsUrlParser.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.AzureDevOpsServer.Git.UnitTests" />
   </ItemGroup>

--- a/src/SourceLink.AzureDevOpsServer.Git/build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
+++ b/src/SourceLink.AzureDevOpsServer.Git/build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkAzureDevOpsServerGitAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.AzureDevOpsServer.Git.dll</_SourceLinkAzureDevOpsServerGitAssemblyFile>
     <_SourceLinkAzureDevOpsServerGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.AzureDevOpsServer.Git.dll</_SourceLinkAzureDevOpsServerGitAssemblyFile>
@@ -53,7 +53,6 @@
     We need to translate ssh URLs to https.
   -->
   <Target Name="TranslateAzureDevOpsServerGitUrlsInSourceControlInformation">
-
     <ItemGroup>
       <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
@@ -68,5 +67,6 @@
       <SourceRoot Include="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
   </Target>
+
 </Project>
- 
+

--- a/src/SourceLink.AzureDevOpsServer.Git/buildMultiTargeting/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
+++ b/src/SourceLink.AzureDevOpsServer.Git/buildMultiTargeting/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.AzureRepos.Git.UnitTests/Microsoft.SourceLink.AzureRepos.Git.UnitTests.csproj
+++ b/src/SourceLink.AzureRepos.Git.UnitTests/Microsoft.SourceLink.AzureRepos.Git.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.AzureRepos.Git\Microsoft.SourceLink.AzureRepos.Git.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.AzureRepos.Git/Microsoft.SourceLink.AzureRepos.Git.csproj
+++ b/src/SourceLink.AzureRepos.Git/Microsoft.SourceLink.AzureRepos.Git.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,6 +13,7 @@
     <PackageTags>MSBuild Tasks Azure DevOps Repos VSTS Git source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
@@ -22,15 +21,20 @@
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
     <Compile Include="..\Common\AzureDevOpsUrlParser.cs" Link="Common\AzureDevOpsUrlParser.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.AzureRepos.Git.UnitTests" />
   </ItemGroup>

--- a/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.props
+++ b/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.props
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <ItemGroup>
     <SourceLinkAzureReposGitHost Include="visualstudio.com" />
     <SourceLinkAzureReposGitHost Include="vsts.me" />
     <SourceLinkAzureReposGitHost Include="dev.azure.com" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.targets
+++ b/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkAzureReposGitAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.AzureRepos.Git.dll</_SourceLinkAzureReposGitAssemblyFile>
     <_SourceLinkAzureReposGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.AzureRepos.Git.dll</_SourceLinkAzureReposGitAssemblyFile>
@@ -40,7 +40,6 @@
     We need to translate ssh URLs to https.
   -->
   <Target Name="TranslateAzureReposGitUrlsInSourceControlInformation">
-
     <ItemGroup>
       <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
@@ -55,5 +54,6 @@
       <SourceRoot Include="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
   </Target>
+
 </Project>
  

--- a/src/SourceLink.AzureRepos.Git/buildMultiTargeting/Microsoft.SourceLink.AzureRepos.Git.props
+++ b/src/SourceLink.AzureRepos.Git/buildMultiTargeting/Microsoft.SourceLink.AzureRepos.Git.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/SourceLink.AzureRepos.Git/buildMultiTargeting/Microsoft.SourceLink.AzureRepos.Git.targets
+++ b/src/SourceLink.AzureRepos.Git/buildMultiTargeting/Microsoft.SourceLink.AzureRepos.Git.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.AzureRepos.Tfvc/Microsoft.SourceLink.AzureRepos.Tfvc.csproj
+++ b/src/SourceLink.AzureRepos.Tfvc/Microsoft.SourceLink.AzureRepos.Tfvc.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -16,11 +14,13 @@
     <PackageTags>MSBuild Tasks Azure DevOps Repos VSTS TFVC source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.AzureRepos.Tfvc/build/Microsoft.SourceLink.AzureRepos.Tfvc.targets
+++ b/src/SourceLink.AzureRepos.Tfvc/build/Microsoft.SourceLink.AzureRepos.Tfvc.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkAzureReposTfvcAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.AzureRepos.Tfvc.dll</_SourceLinkAzureReposTfvcAssemblyFile>
     <_SourceLinkAzureReposTfvcAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.AzureRepos.Tfvc.dll</_SourceLinkAzureReposTfvcAssemblyFile>

--- a/src/SourceLink.AzureRepos.Tfvc/buildMultiTargeting/Microsoft.SourceLink.AzureRepos.Tfvc.targets
+++ b/src/SourceLink.AzureRepos.Tfvc/buildMultiTargeting/Microsoft.SourceLink.AzureRepos.Tfvc.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.Bitbucket.Git.UnitTests/Microsoft.SourceLink.Bitbucket.Git.UnitTests.csproj
+++ b/src/SourceLink.Bitbucket.Git.UnitTests/Microsoft.SourceLink.Bitbucket.Git.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.Bitbucket.Git\Microsoft.SourceLink.Bitbucket.Git.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Bitbucket.Git/Microsoft.SourceLink.Bitbucket.Git.csproj
+++ b/src/SourceLink.Bitbucket.Git/Microsoft.SourceLink.Bitbucket.Git.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
@@ -15,21 +13,27 @@
     <PackageTags>MSBuild Tasks Bitbucket source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.Bitbucket.Git.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />

--- a/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.props
+++ b/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.props
@@ -1,7 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <ItemGroup>
-    <SourceLinkBitbucketGitHost Include="bitbucket.org" EnterpriseEdition="false"/>
+    <SourceLinkBitbucketGitHost Include="bitbucket.org" EnterpriseEdition="false" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.targets
+++ b/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkBitbucketAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.Bitbucket.Git.dll</_SourceLinkBitbucketAssemblyFile>
     <_SourceLinkBitbucketAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.Bitbucket.Git.dll</_SourceLinkBitbucketAssemblyFile>
@@ -48,7 +48,6 @@
     We need to translate ssh URLs to https.
   -->
   <Target Name="TranslateBitbucketGitUrlsInSourceControlInformation">
-
     <ItemGroup>
       <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
@@ -62,7 +61,6 @@
       <SourceRoot Remove="@(SourceRoot)"/>
       <SourceRoot Include="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
-  
-</Target>
+  </Target>
 
 </Project>

--- a/src/SourceLink.Bitbucket.Git/buildMultiTargeting/Microsoft.SourceLink.Bitbucket.Git.props
+++ b/src/SourceLink.Bitbucket.Git/buildMultiTargeting/Microsoft.SourceLink.Bitbucket.Git.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/SourceLink.Bitbucket.Git/buildMultiTargeting/Microsoft.SourceLink.Bitbucket.Git.targets
+++ b/src/SourceLink.Bitbucket.Git/buildMultiTargeting/Microsoft.SourceLink.Bitbucket.Git.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.Common.UnitTests/Microsoft.SourceLink.Common.UnitTests.csproj
+++ b/src/SourceLink.Common.UnitTests/Microsoft.SourceLink.Common.UnitTests.csproj
@@ -1,20 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
   <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
     <ProjectReference Include="..\SourceLink.Common\Microsoft.SourceLink.Common.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Common/Microsoft.SourceLink.Common.csproj
+++ b/src/SourceLink.Common/Microsoft.SourceLink.Common.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- NuGet: Using an explicit nuspec file to customize TFM directory -->
@@ -16,17 +14,20 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\PathUtilities.cs" Link="Common\PathUtilities.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.Common.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Common/build/InitializeSourceControlInformation.targets
+++ b/src/SourceLink.Common/build/InitializeSourceControlInformation.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <UsingTask TaskName="Microsoft.SourceLink.Common.SourceLinkHasSingleProvider" AssemblyFile="$(_MicrosoftSourceLinkCommonAssemblyFile)"/>
 
   <Target Name="_SourceLinkHasSingleProvider">
@@ -41,4 +41,5 @@
       </SourceRoot>
     </ItemGroup>
   </Target>
+
 </Project>

--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
+++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_MicrosoftSourceLinkCommonAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.Common.dll</_MicrosoftSourceLinkCommonAssemblyFile>
     <_MicrosoftSourceLinkCommonAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.Common.dll</_MicrosoftSourceLinkCommonAssemblyFile>
@@ -17,5 +17,6 @@
       Do not generate SourceLink when building in the IDE or for Live Unit Testing.
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == '' and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'">true</EnableSourceLink>
-  </PropertyGroup>  
+  </PropertyGroup>
+
 </Project>

--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
+++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="InitializeSourceControlInformation.targets"/>
+
+  <Import Project="InitializeSourceControlInformation.targets" />
   
   <UsingTask TaskName="Microsoft.SourceLink.Common.GenerateSourceLinkFile" AssemblyFile="$(_MicrosoftSourceLinkCommonAssemblyFile)"/>
 
@@ -49,7 +49,6 @@
           DependsOnTargets="_SetSourceLinkFilePath;$(_GenerateSourceLinkFileDependsOnTargets);_InitializeSourceRootMappedPathsOpt;$(SourceLinkUrlInitializerTargets)"
           Condition="'$(EnableSourceLink)' == 'true' and '$(DebugType)' != 'none'"
           Outputs="$(_SourceLinkFilePath)">
-
     <!--- Suppress warning if targets are imported from an SDK without a package reference. -->
     <Microsoft.SourceLink.Common.GenerateSourceLinkFile
       SourceRoots="@(SourceRoot)"
@@ -80,5 +79,5 @@
           DependsOnTargets="InitializeSourceControlInformation;_GenerateSourceLinkFile"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true'"
           BeforeTargets="$(_GenerateSourceLinkFileBeforeTargets)"/>
-  
+
 </Project>

--- a/src/SourceLink.Common/buildMultiTargeting/Microsoft.SourceLink.Common.props
+++ b/src/SourceLink.Common/buildMultiTargeting/Microsoft.SourceLink.Common.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/SourceLink.Common/buildMultiTargeting/Microsoft.SourceLink.Common.targets
+++ b/src/SourceLink.Common/buildMultiTargeting/Microsoft.SourceLink.Common.targets
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\InitializeSourceControlInformation.targets"/>
+
+  <Import Project="..\build\InitializeSourceControlInformation.targets" />
   
   <!--
     Workaround for https://github.com/Microsoft/msbuild/issues/3294.

--- a/src/SourceLink.Git.IntegrationTests/Microsoft.SourceLink.Git.IntegrationTests.csproj
+++ b/src/SourceLink.Git.IntegrationTests/Microsoft.SourceLink.Git.IntegrationTests.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <ProjectReference Include="..\Microsoft.Build.Tasks.Git\Microsoft.Build.Tasks.Git.csproj" />
@@ -12,4 +12,5 @@
     <ProjectReference Include="..\SourceLink.GitWeb\Microsoft.SourceLink.GitWeb.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitHub.UnitTests/Microsoft.SourceLink.GitHub.UnitTests.csproj
+++ b/src/SourceLink.GitHub.UnitTests/Microsoft.SourceLink.GitHub.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.GitHub\Microsoft.SourceLink.GitHub.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitHub/Microsoft.SourceLink.GitHub.csproj
+++ b/src/SourceLink.GitHub/Microsoft.SourceLink.GitHub.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,23 +13,30 @@
     <PackageTags>MSBuild Tasks GitHub source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.GitHub.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.props
+++ b/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.props
@@ -1,7 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <ItemGroup>
-    <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.githubusercontent.com"/>
+    <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.githubusercontent.com" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets
+++ b/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkGitHubAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.GitHub.dll</_SourceLinkGitHubAssemblyFile>
     <_SourceLinkGitHubAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.GitHub.dll</_SourceLinkGitHubAssemblyFile>
@@ -48,7 +48,6 @@
     We need to translate ssh URLs to https.
   -->
   <Target Name="TranslateGitHubUrlsInSourceControlInformation">
-
     <ItemGroup>
       <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
@@ -62,7 +61,6 @@
       <SourceRoot Remove="@(SourceRoot)"/>
       <SourceRoot Include="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
-  
-</Target>
+  </Target>
 
 </Project>

--- a/src/SourceLink.GitHub/buildMultiTargeting/Microsoft.SourceLink.GitHub.props
+++ b/src/SourceLink.GitHub/buildMultiTargeting/Microsoft.SourceLink.GitHub.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/SourceLink.GitHub/buildMultiTargeting/Microsoft.SourceLink.GitHub.targets
+++ b/src/SourceLink.GitHub/buildMultiTargeting/Microsoft.SourceLink.GitHub.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.GitLab.UnitTests/Microsoft.SourceLink.GitLab.UnitTests.csproj
+++ b/src/SourceLink.GitLab.UnitTests/Microsoft.SourceLink.GitLab.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.GitLab\Microsoft.SourceLink.GitLab.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitLab/Microsoft.SourceLink.GitLab.csproj
+++ b/src/SourceLink.GitLab/Microsoft.SourceLink.GitLab.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,22 +13,29 @@
     <PackageTags>MSBuild Tasks GitLab source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.GitLab.UnitTests" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.props
+++ b/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.props
@@ -1,7 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <ItemGroup>
     <SourceLinkGitLabHost Include="gitlab.com" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets
+++ b/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkGitLabAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.GitLab.dll</_SourceLinkGitLabAssemblyFile>
     <_SourceLinkGitLabAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.GitLab.dll</_SourceLinkGitLabAssemblyFile>

--- a/src/SourceLink.GitLab/buildMultiTargeting/Microsoft.SourceLink.GitLab.props
+++ b/src/SourceLink.GitLab/buildMultiTargeting/Microsoft.SourceLink.GitLab.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/SourceLink.GitLab/buildMultiTargeting/Microsoft.SourceLink.GitLab.targets
+++ b/src/SourceLink.GitLab/buildMultiTargeting/Microsoft.SourceLink.GitLab.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.GitWeb.UnitTests/Microsoft.SourceLink.GitWeb.UnitTests.csproj
+++ b/src/SourceLink.GitWeb.UnitTests/Microsoft.SourceLink.GitWeb.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.GitWeb\Microsoft.SourceLink.GitWeb.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitWeb/Microsoft.SourceLink.GitWeb.csproj
+++ b/src/SourceLink.GitWeb/Microsoft.SourceLink.GitWeb.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,24 +13,30 @@
     <PackageTags>MSBuild Tasks GitWeb source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Resources.resx"/>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.GitWeb.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.GitWeb/build/Microsoft.SourceLink.GitWeb.targets
+++ b/src/SourceLink.GitWeb/build/Microsoft.SourceLink.GitWeb.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkGitWebAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.GitWeb.dll</_SourceLinkGitWebAssemblyFile>
     <_SourceLinkGitWebAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.GitWeb.dll</_SourceLinkGitWebAssemblyFile>
@@ -63,4 +63,5 @@
       <SourceRoot Include="@(_TranslatedSourceRoot)" />
     </ItemGroup>
   </Target>
+
 </Project>

--- a/src/SourceLink.GitWeb/buildMultiTargeting/Microsoft.SourceLink.GitWeb.targets
+++ b/src/SourceLink.GitWeb/buildMultiTargeting/Microsoft.SourceLink.GitWeb.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.Gitea.UnitTests/Microsoft.SourceLink.Gitea.UnitTests.csproj
+++ b/src/SourceLink.Gitea.UnitTests/Microsoft.SourceLink.Gitea.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.Gitea\Microsoft.SourceLink.Gitea.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Gitea/Microsoft.SourceLink.Gitea.csproj
+++ b/src/SourceLink.Gitea/Microsoft.SourceLink.Gitea.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,22 +13,29 @@
     <PackageTags>MSBuild Tasks Gitea source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.Gitea.UnitTests" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Gitea/build/Microsoft.SourceLink.Gitea.targets
+++ b/src/SourceLink.Gitea/build/Microsoft.SourceLink.Gitea.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkGiteaAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.Gitea.dll</_SourceLinkGiteaAssemblyFile>
     <_SourceLinkGiteaAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.Gitea.dll</_SourceLinkGiteaAssemblyFile>
@@ -48,7 +48,6 @@
     We need to translate ssh URLs to https.
   -->
   <Target Name="TranslateGiteaUrlsInSourceControlInformation">
-
     <ItemGroup>
       <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
     </ItemGroup>

--- a/src/SourceLink.Gitea/buildMultiTargeting/Microsoft.SourceLink.Gitea.targets
+++ b/src/SourceLink.Gitea/buildMultiTargeting/Microsoft.SourceLink.Gitea.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.Gitee.UnitTests/Microsoft.SourceLink.Gitee.UnitTests.csproj
+++ b/src/SourceLink.Gitee.UnitTests/Microsoft.SourceLink.Gitee.UnitTests.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SourceLink.Gitee\Microsoft.SourceLink.Gitee.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Gitee/Microsoft.SourceLink.Gitee.csproj
+++ b/src/SourceLink.Gitee/Microsoft.SourceLink.Gitee.csproj
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetMinimum);$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -15,23 +13,30 @@
     <PackageTags>MSBuild Tasks Gitee source link</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
     <Compile Include="..\Common\Names.cs" Link="Common\Names.cs" />
     <Compile Include="..\Common\GetSourceLinkUrlGitTask.cs" Link="Common\GetSourceLinkUrlGitTask.cs" />
     <Compile Include="..\Common\TranslateRepositoryUrlGitTask.cs" Link="Common\TranslateRepositoryUrlGitTask.cs" />
     <Compile Include="..\Common\UriUtilities.cs" Link="Common\UriUtilities.cs" />
-    <EmbeddedResource Include="..\Common\CommonResources.resx" Link="Common\CommonResources.resx">
-      <Namespace>Microsoft.Build.Tasks.SourceControl</Namespace>
-      <GenerateSource>true</GenerateSource>
-    </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Common\CommonResources.resx"
+                      Link="Common\CommonResources.resx"
+                      Namespace="Microsoft.Build.Tasks.SourceControl"
+                      GenerateSource="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SourceLink.Gitee.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.SourceLink.Git.IntegrationTests" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.props
+++ b/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.props
@@ -1,7 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <ItemGroup>
-    <SourceLinkGiteeHost Include="gitee.com" ContentUrl="https://gitee.com"/>
+    <SourceLinkGiteeHost Include="gitee.com" ContentUrl="https://gitee.com" />
   </ItemGroup>
+
 </Project>

--- a/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.targets
+++ b/src/SourceLink.Gitee/build/Microsoft.SourceLink.Gitee.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <_SourceLinkGiteeAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.SourceLink.Gitee.dll</_SourceLinkGiteeAssemblyFile>
     <_SourceLinkGiteeAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\core\Microsoft.SourceLink.Gitee.dll</_SourceLinkGiteeAssemblyFile>
@@ -48,7 +48,6 @@
     We need to translate ssh URLs to https.
   -->
   <Target Name="TranslateGiteeUrlsInSourceControlInformation">
-
     <ItemGroup>
       <_TranslatedSourceRoot Remove="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
@@ -62,7 +61,6 @@
       <SourceRoot Remove="@(SourceRoot)"/>
       <SourceRoot Include="@(_TranslatedSourceRoot)"/>
     </ItemGroup>
-  
-</Target>
+  </Target>
 
 </Project>

--- a/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.props
+++ b/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.props
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).props"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).props" />
+
 </Project>

--- a/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.targets
+++ b/src/SourceLink.Gitee/buildMultiTargeting/Microsoft.SourceLink.Gitee.targets
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFileName).targets"/>
+
+  <Import Project="..\build\$(MSBuildThisFileName).targets" />
+
 </Project>

--- a/src/SourceLink.Tools.UnitTests/Microsoft.SourceLink.Tools.UnitTests.csproj
+++ b/src/SourceLink.Tools.UnitTests/Microsoft.SourceLink.Tools.UnitTests.csproj
@@ -1,14 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
+
   <Import Project="..\SourceLink.Tools\Microsoft.SourceLink.Tools.projitems" Label="Shared" />
+
 </Project>

--- a/src/SourceLink.Tools/Microsoft.SourceLink.Tools.Package.csproj
+++ b/src/SourceLink.Tools/Microsoft.SourceLink.Tools.Package.csproj
@@ -1,24 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
+
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <DebugType>none</DebugType>
-    <GenerateDependencyFile>false</GenerateDependencyFile>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
     <IsSourcePackage>true</IsSourcePackage>
     <PackageId>Microsoft.SourceLink.Tools</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <PackageDescription>
-      Package containing sources of tools for reading Source Link.
-    </PackageDescription>
+    <PackageDescription>Package containing sources of tools for reading Source Link.</PackageDescription>
     <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -1,22 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
     <IsShipping>false</IsShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCore)" />
-    <PackageReference Include="xunit.core" Version="$(XunitVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.Combinatorial" version="$(XunitCombinatorialVersion)" />
+    <PackageReference Include="xunit.core" Version="$(XunitVersion)" />
     <!-- Upgrade the NETStandard.Library transitive xunit dependency to avoid transitive 1.x NS dependencies. -->
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -41,4 +38,5 @@
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
   </Target>
+
 </Project>

--- a/src/dotnet-sourcelink/dotnet-sourcelink.csproj
+++ b/src/dotnet-sourcelink/dotnet-sourcelink.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <!-- Allow tool to roll forward to a newer major version. -->
+    <RollForward>Major</RollForward>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
@@ -19,4 +22,5 @@
   </ItemGroup>
 
   <Import Project="..\SourceLink.Tools\Microsoft.SourceLink.Tools.projitems" Label="Shared" />
+
 </Project>

--- a/src/dotnet-sourcelink/runtimeconfig.template.json
+++ b/src/dotnet-sourcelink/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-    "rollForwardOnNoCandidateFx": 2
-}


### PR DESCRIPTION
1. ~~Remove license headers from non-shipping assets (project files)~~ https://github.com/dotnet/sourcelink/pull/1014
2. Use the Microsoft.Build.NoTargets SDK for content-only packages That avoids invoking the compiler without defining custom targets and makes the repository use the same path as other repositories in the stack.
3. Delete runtimeconfig.template.json in favor of the in-built `"<RollForward>...</RollForward>"` switch.
4. Remove not needed sourcebuild target.
5. Group dependencies in Versions.props by repositories. Remove the now unneeded Microsoft.NET.Test.Sdk entry.
6. Define target frameworks for source build centrally in one place.
7. Remove unnecessary package dependencies from projects.
8. Apply code styling:
   - "empty line after Project tag and before closing Project tag"
   - "empty line between groups (property, item, target)"
   - "TargetFramework(s) should be the first property in the project"
9. Remove unnecessary PrivateAssets="all" attributes from four ProjectReference items.