### PR TITLE
Fix packaging of Microsoft.Build.StandardCI

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <GenerateResxSource>true</GenerateResxSource>
     
     <!-- Produce snupkg in official builds (when not embedding PDBs to dlls) -->
-    <IncludeSymbols Condition="'$(DebugType)' != 'embedded'">true</IncludeSymbols>
+    <IncludeSymbols Condition="'$(DebugType)' != 'embedded' and '$(UsingMicrosoftNoTargetsSdk)' != 'true'">true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   


### PR DESCRIPTION
Fixes https://github.com/dotnet/sourcelink/issues/1044

When performing an official build, DebugType is portable which causes the IncludeSymbols flag in src/Directory.Build.props to evaluate to true. The Microsoft.Build.StandardCI project uses the Microsoft.Build.NoTargets SDK which doesn't produce a build output (as the package only ships a content file and not a binary). Change the condition to check if the NoTargets SDK is used which indicates that a symbol shouldn't be included.