### PR TITLE
Remove default publishing settings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,8 +134,3 @@ stages:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      # Symbol validation isn't being very reliable lately. This should be enabled back
-      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
-      enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,0 @@
-<Project>
-   <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
-   </PropertyGroup>
-</Project>


### PR DESCRIPTION
publishing version 3 is already the default, same for the symbol validation.