### PR TITLE
Enable Source Link in design-time build

### DIFF
--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
+++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
@@ -7,14 +7,13 @@
 
   <PropertyGroup>
     <!--
-      Do not query source control manager for any information when building in the IDE or for Live Unit Testing.
-      Features that need this information will be disabled if false.
+      Used to suppress querying source control and features that use the information (e.g. git commit SHA).
     -->
-    <EnableSourceControlManagerQueries Condition="'$(EnableSourceControlManagerQueries)' == '' and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'">true</EnableSourceControlManagerQueries>
-    
+    <EnableSourceControlManagerQueries Condition="'$(EnableSourceControlManagerQueries)' == ''">true</EnableSourceControlManagerQueries>
+
     <!--
       Do not generate SourceLink when building in the IDE or for Live Unit Testing.
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == '' and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'">true</EnableSourceLink>
-  </PropertyGroup>  
+  </PropertyGroup>
 </Project>

--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
+++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
@@ -14,11 +14,14 @@
     Triggers SetEmbeddedFilesFromSourceControlManagerUntrackedFiles target defined by a source control package Microsoft.Build.Tasks.{Git|Tfvc|...}.
     Assumes that all targets that generate source files and add them to Compile items run before BeforeCompile target.
     This is a convention established by common targets.
+    
+    Disabled for design-time build since calculating untracked files is non-trivial operation
+    and embedding them only affects the content of the generated PDB, which has no impact on design-time build.
   -->
   <Target Name="_SetEmbeddedFilesFromSourceControlManagerUntrackedFiles"
           DependsOnTargets="BeforeCompile;SetEmbeddedFilesFromSourceControlManagerUntrackedFiles"
           BeforeTargets="CoreCompile"
-          Condition="'$(EmbedUntrackedSources)' == 'true' and '$(EmbedAllSources)' != 'true' and '$(DebugType)' != 'none' and '$(EnableSourceControlManagerQueries)' == 'true'" />
+          Condition="'$(EmbedUntrackedSources)' == 'true' and '$(EmbedAllSources)' != 'true' and '$(DebugType)' != 'none' and '$(EnableSourceControlManagerQueries)' == 'true' and '$(DesignTimeBuild)' != 'true'" />
 
   <!--
     If defined populates MappedPath metadata of SourceRoot items.

--- a/src/SourceLink.Git.IntegrationTests/TargetTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/TargetTests.cs
@@ -90,6 +90,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
+                    ProjectSourceRoot,
                     "true",
                     "",
                     ""
@@ -125,6 +126,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
+                    ProjectSourceRoot,
                     "true",
                     "",
                     ""

--- a/src/SourceLink.Git.IntegrationTests/TargetTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/TargetTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
-                    "True",
+                    "true",
                     "",
                     ""
                 },
@@ -125,7 +125,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
-                    "True",
+                    "true",
                     "",
                     ""
                 },

--- a/src/SourceLink.Git.IntegrationTests/TargetTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/TargetTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
-                    "",
+                    "True",
                     "",
                     ""
                 },
@@ -125,7 +125,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
-                    "",
+                    "True",
                     "",
                     ""
                 },


### PR DESCRIPTION
Source Link, which is now included in the SDK and enabled by default, is causing Hot Reload to block stepping. Depending on timing of design-time builds this intermittently prevents the customer from debugging their application. Hot Reload blocks stepping due to differences in generated AssemlyInfo.cs files caused by Source Link targets.

Git commit SHA that is now included in `AssemblyInformationalVersion` attribute by default was not set in design-time build. This caused the content of `*.AssemlyInfo.cs` to differ between regular build and design-time build. If design-time build run after the debugging has started Hot Reload registered this difference as a change to be applied. Changing assembly level attributes is currently a rude edit and thus the change application is blocked, which in turns blocks stepping.

Fixes https://github.com/dotnet/sdk/issues/36666

## Customer Impact

Debugging projects is broken.

A workaround is to set `EnableSourceControlManagerQueries` to true globally (for all projects in the repo), e.g. add `Directory.Build.props` to the source root with:

```xml
<Project>
  <PropertyGroup>
    <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
  </PropertyGroup>
</Project>
```

## Regression?

- [x] Yes
- [ ] No

7.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change sets property that enables the same code path that's already executed in regular build to run in design-time build.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A

