### PR TITLE
Fixes handling of local and network paths in remote URL

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitDataTests.cs
@@ -54,7 +54,7 @@ url=https://github.com/test-org/test-sub
             Assert.Equal("1111111111111111111111111111111111111111", repository.GetHeadCommitSha());
 
             var warnings = new List<(string, object?[])>();
-            var sourceRoots = GitOperations.GetSourceRoots(repository, remoteName: null, warnOnMissingCommit: true, (message, args) => warnings.Add((message, args)));
+            var sourceRoots = GitOperations.GetSourceRoots(repository, remoteName: null, warnOnMissingCommitOrUnsupportedUri: true, (message, args) => warnings.Add((message, args)));
             AssertEx.Equal(new[]
             {
                 $@"'{repoDir.Path}{s}' SourceControl='git' RevisionId='1111111111111111111111111111111111111111' ScmRepositoryUrl='http://github.com/test-org/test-repo'",

--- a/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Build.Tasks.Git
             
             RepositoryId = repository.GitDirectory;
             WorkingDirectory = repository.WorkingDirectory;
-            Url = GitOperations.GetRepositoryUrl(repository, RemoteName, warnOnMissingRemote: !NoWarnOnMissingInfo, Log.LogWarning);
-            Roots = GitOperations.GetSourceRoots(repository, RemoteName, warnOnMissingCommit: !NoWarnOnMissingInfo, Log.LogWarning);
+            Url = GitOperations.GetRepositoryUrl(repository, RemoteName, warnOnMissingOrUnsupportedRemote: !NoWarnOnMissingInfo, Log.LogWarning);
+            Roots = GitOperations.GetSourceRoots(repository, RemoteName, warnOnMissingCommitOrUnsupportedUri: !NoWarnOnMissingInfo, Log.LogWarning);
             RevisionId = repository.GetHeadCommitSha();
         }
     }


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/t/VS-178:-Unable-to-locate-repository-wit/10519177 and https://developercommunity.visualstudio.com/t/Repository-URL-evaluation-exceeds-maximu/10523155

The implementation didn't correctly handle scenario where a repository is cloned from a _bare_ repository located on a local path or a network share. Source Link in this scenario can't be easily supported by the debugger and we should disable it without failing the build.

## Customer Impact

Build in repositories that are cloned from a file share fails after the customer upgrades their toolset to .NET 8 SDK.

## Regression?

- [x] Yes
- [ ] No

7.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A
