### PR TITLE
Allow EOLN in quoted config value and report better message when parsing fails

### DIFF
--- a/src/Microsoft.Build.Tasks.Git/Resources.resx
+++ b/src/Microsoft.Build.Tasks.Git/Resources.resx
@@ -198,4 +198,13 @@
   <data name="RepositoryUrlEvaluationExceededMaximumAllowedDepth" xml:space="preserve">
     <value>Repository URL evaluation exceeded maximum allowed depth of {0} local repositories.</value>
   </data>
+  <data name="UnexpectedEndOfFile" xml:space="preserve">
+    <value>Unexpected end of file.</value>
+  </data>
+  <data name="UnexpectedCharacter" xml:space="preserve">
+    <value>Unexpected character {0}.</value>
+  </data>
+  <data name="ErrorParsingConfigLineInFile" xml:space="preserve">
+    <value>Error parsing config line {0} in file '{1}': {2}</value>
+  </data>
 </root>

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.cs.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Rekurze konfiguračního souboru překročila maximální povolenou hloubku {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Chyba při čtení informací o úložišti Git: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Nejde najít úložiště s pracovním adresářem, který obsahuje adresář {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.de.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Die Rekursion der Konfigurationsdatei hat die maximal zulässige Tiefe von {0} überschritten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Fehler beim Lesen der Git-Repositoryinformationen: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Das Repository mit dem Arbeitsverzeichnis, welches das Verzeichnis "{0}" enthält, wurde nicht gefunden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.es.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La recursividad del archivo de configuración superó la profundidad máxima permitida de {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Error al leer la información del repositorio de Git: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">No se puede encontrar el repositorio con el directorio de trabajo que contiene el directorio "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.fr.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La récursivité du fichier de configuration a dépassé la profondeur maximale autorisée de {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Erreur lors de la lecture des informations du dépôt git : {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Impossible de localiser le dépôt avec le répertoire de travail contenant le répertoire '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.it.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La ricorsione del file di configurazione ha superato la profondità massima consentita di {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Si è verificato un errore durante la lettura delle informazioni sul repository GIT: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Non è possibile individuare il repository con la directory di lavoro che contiene la directory '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ja.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">構成ファイルの再帰が、許容されている深さの上限 {0} を超えました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Git リポジトリ情報の読み取りでエラーが発生しました: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">ディレクトリ '{0}' を含む作業ディレクトリがあるリポジトリが見つかりません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ko.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">구성 파일 재귀가 허용되는 최대 깊이 {0}을(를) 초과했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Git 리포지토리 정보를 읽는 동안 오류가 발생했습니다. {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">디렉터리 '{0}'이(가) 포함된 작업 디렉터리로 리포지토리를 찾을 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.pl.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Rekursja pliku konfiguracji przekroczyła maksymalną dozwoloną głębokość równą {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Błąd podczas odczytywania informacji o repozytorium git: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Nie można zlokalizować repozytorium z katalogiem roboczym zawierającym katalog „{0}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">A recursão do arquivo de configuração excedeu a profundidade máxima permitida de {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Erro ao ler informações do repositório git: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Não é possível localizar o repositório com o diretório de trabalho que contém o diretório '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.ru.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Для рекурсии файла конфигурации превышена максимально допустимая глубина {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Ошибка при чтении сведений о репозитории Git: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">Не удается найти репозиторий с рабочим каталогом, содержащим каталог "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.tr.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Yapılandırma dosyası özyinelemesi izin verilen maksimum {0} derinliğini aştı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">Git deposu bilgileri okunurken hata: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">'{0}' dizinini içeren çalışma dizini içeren depo bulunamıyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">配置文件递归超过了允许的最大深度 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">读取 GIT 存储库信息时出错: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">找不到具有带目录“{0}”的工作目录的存储库。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">

--- a/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.Build.Tasks.Git/xlf/Resources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">組態檔遞迴已超過最大允許深度 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorParsingConfigLineInFile">
+        <source>Error parsing config line {0} in file '{1}': {2}</source>
+        <target state="new">Error parsing config line {0} in file '{1}': {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingGitRepositoryInformation">
         <source>Error reading git repository information: {0}</source>
         <target state="translated">讀取 git 存放庫資訊時發生錯誤: {0}</target>
@@ -115,6 +120,16 @@
       <trans-unit id="UnableToLocateRepository">
         <source>Unable to locate repository with working directory that contains directory '{0}'.</source>
         <target state="translated">找不到具有包含目錄 '{0}' 之工作目錄的存放庫。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacter">
+        <source>Unexpected character {0}.</source>
+        <target state="new">Unexpected character {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedEndOfFile">
+        <source>Unexpected end of file.</source>
+        <target state="new">Unexpected end of file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedRepositoryExtension">


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/t/Error-reading-repository-information-F/10519873

The implementation didn't correctly handle scenario where a quoted value in git configuration file had line breaks.

## Customer Impact

Build in repositories with such configuration fails after the customer upgrades their toolset to .NET 8 SDK.

## Regression?

- [x] Yes
- [ ] No

7.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A
