### PR TITLE
Add CompileBefore to Git untracked files consideration

### DIFF
--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -50,7 +50,7 @@
       RepositoryId="$(_GitRepositoryId)"
       ConfigurationScope="$(GitRepositoryConfigurationScope)"
       ProjectDirectory="$(MSBuildProjectDirectory)"
-      Files="@(Compile)"
+      Files="@(CompileBefore);@(Compile)"
       Condition="'$(_GitRepositoryId)' != ''">
 
       <Output TaskParameter="UntrackedFiles" ItemName="EmbeddedFiles" />


### PR DESCRIPTION
`SetEmbeddedFilesFromSourceControlManagerUntrackedFiles` [only considers files if they're in `@(Compile)`](https://github.com/dotnet/sourcelink/blob/a22426a46745b8fe77b9d306fa4bc1d03eff44ea/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets#L53). In an F# project, `TargetFrameworkMonikerAssemblyAttributesPath` is not in `@(Compile)` but [is instead in `@CompileBefore`](https://github.com/dotnet/fsharp/blob/bc3dd9ffaaad7898a68de4828aa0a08e1bb1461b/src/FSharp.Build/Microsoft.FSharp.Targets#L436). The result is that the F# compiler never even attempts to embed `obj/Release/netstandard2.0/.NETStandard,Version=v2.0.AssemblyAttributes.fs` (for example), because it was never added to `@(EmbeddedFiles)`.

It's possible that the correct fix is instead in Microsoft.FSharp.Targets. The behaviour of adding to `CompileBefore` rather than to `Compile` was added in https://github.com/dotnet/fsharp/commit/01c621c04666bf740f01eb73eb779f6fb5a2c7f1, which is extremely vague and dates back before pull requests and GitHub were a thing; so I can't find any of the context for it.