### PR TITLE
Dispose HttpClientHandler when done with it

### DIFF
--- a/src/dotnet-sourcelink/Program.cs
+++ b/src/dotnet-sourcelink/Program.cs
@@ -211,7 +211,7 @@ namespace Microsoft.SourceLink.Tools
 
             if (!offline)
             {
-                var handler = new HttpClientHandler();
+                using var handler = new HttpClientHandler();
                 if (handler.SupportsAutomaticDecompression)
                     handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
 


### PR DESCRIPTION
It is an IDisposable, and some static analysis tools complain that it doesn't get Dispose()d correctly.