### PR TITLE
Populate RepositoryBranch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -170,6 +170,7 @@ Additional source-control specific metadata may be defined (depends on the sourc
 For example, for Git:
 
 - _RepositoryUrl_: e.g. `http://github.com/dotnet/corefx`
+- _BranchName_: e.g. `refs/heads/main` (may be null if branch is in a detached HEAD state)
 
 For TFVC:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,11 @@ The default value is `true`. Set to `false` to suppress publishing `SourceRevisi
 Set by target `InitializeSourceControlInformationFromSourceControlManager` and consumed by NuGet `Pack` target and `GenerateAssemblyInfo` target. 
 May be used by custom targets that need this information.
 
+### SourceBranchName
+
+Set by target `InitializeSourceControlInformationFromSourceControlManager` and consumed by NuGet `Pack` target.
+May be used by custom targets that need this information.
+
 ### EnableSourceLink
 
 This property is implicitly set to `true` by a Source Link package. Including a Source Link package thus enables Source Link generation unless explicitly disabled by the project by setting this property to `false`.

--- a/src/Common/Utilities/Names.cs
+++ b/src/Common/Utilities/Names.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Build.Tasks.SourceControl
             public const string NestedRoot = nameof(NestedRoot);
             public const string MappedPath = nameof(MappedPath);
             public const string SourceLinkUrl = nameof(SourceLinkUrl);
+            public const string BranchName = nameof(BranchName);
 
             public const string MappedPathFullName = nameof(SourceRoot) + "." + nameof(MappedPath);
             public const string SourceLinkUrlFullName = nameof(SourceRoot) + "." + nameof(SourceLinkUrl);

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -539,5 +539,37 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
 
             Assert.Null(GitRepository.GetSubmoduleReferenceResolver(submoduleWorkingDir.Path)?.ResolveHeadReference());
         }
+
+        [Fact]
+        public void GetHeadBranchName()
+        {
+            using var temp = new TempRoot();
+
+            var commonDir = temp.CreateDirectory();
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+            refsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000 \t\v\r\n");
+
+            var gitDir = temp.CreateDirectory();
+            gitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/master \t\v\r\n");
+
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, commonDir.Path, workingDirectory: null);
+            Assert.Equal("refs/heads/master", repository.GetBranchName());
+        }
+
+        [Fact]
+        public void GetHeadBranchName_DetachedHead()
+        {
+            using var temp = new TempRoot();
+
+            var commonDir = temp.CreateDirectory();
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+            refsHeadsDir.CreateFile("master").WriteAllText("0000000000000000000000000000000000000000 \t\v\r\n");
+
+            var gitDir = temp.CreateDirectory();
+            gitDir.CreateFile("HEAD").WriteAllText("0000000000000000000000000000000000000000 \t\v\r\n");
+
+            var repository = new GitRepository(GitEnvironment.Empty, GitConfig.Empty, gitDir.Path, commonDir.Path, workingDirectory: null);
+            Assert.Null(repository.GetBranchName());
+        }
     }
 }

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/TestUtilities.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/TestUtilities.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var containingRoot = sourceRoot.GetMetadata("ContainingRoot");
             var scmRepositoryUrl = sourceRoot.GetMetadata("ScmRepositoryUrl");
             var sourceLinkUrl = sourceRoot.GetMetadata("SourceLinkUrl");
+            var branchName = sourceRoot.GetMetadata("BranchName");
 
             return $"'{sourceRoot.ItemSpec}'" +
               (string.IsNullOrEmpty(sourceControl) ? "" : $" SourceControl='{sourceControl}'") +
@@ -24,7 +25,8 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
               (string.IsNullOrEmpty(nestedRoot) ? "" : $" NestedRoot='{nestedRoot}'") +
               (string.IsNullOrEmpty(containingRoot) ? "" : $" ContainingRoot='{containingRoot}'") +
               (string.IsNullOrEmpty(scmRepositoryUrl) ? "" : $" ScmRepositoryUrl='{scmRepositoryUrl}'") +
-              (string.IsNullOrEmpty(sourceLinkUrl) ? "" : $" SourceLinkUrl='{sourceLinkUrl}'");
+              (string.IsNullOrEmpty(sourceLinkUrl) ? "" : $" SourceLinkUrl='{sourceLinkUrl}'") +
+              (string.IsNullOrEmpty(branchName) ? "" : $" BranchName='{branchName}'");
         }
 
         public static string InspectDiagnostic((string Message, object?[] Args) warning)

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Build.Tasks.Git
         {
             string reference = ReadReferenceFromFile(Path.Combine(_gitDirectory, GitRepository.GitHeadFileName));
 
-            return TryGetReferenceName(reference, out string? name) ? name : null;
+            return TryGetReferenceName(reference, out var name) ? name : null;
         }
 
         public string? ResolveReference(string reference)
@@ -185,7 +185,7 @@ namespace Microsoft.Build.Tasks.Git
         {
             // See https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-HEAD
 
-            if (TryGetReferenceName(reference, out string? symRef))
+            if (TryGetReferenceName(reference, out var symRef))
             {
                 if (lazyVisitedReferences != null && !lazyVisitedReferences.Add(symRef))
                 {

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -152,10 +153,30 @@ namespace Microsoft.Build.Tasks.Git
         public string? ResolveHeadReference()
             => ResolveReference(ReadReferenceFromFile(Path.Combine(_gitDirectory, GitRepository.GitHeadFileName)));
 
+        public string? GetBranchForHead()
+        {
+            string reference = ReadReferenceFromFile(Path.Combine(_gitDirectory, GitRepository.GitHeadFileName));
+
+            return TryGetReferenceName(reference, out string? name) ? name : null;
+        }
+
         public string? ResolveReference(string reference)
         {
             HashSet<string>? lazyVisitedReferences = null;
             return ResolveReference(reference, ref lazyVisitedReferences);
+        }
+
+        private static bool TryGetReferenceName(string reference, [NotNullWhen(true)] out string? name)
+        {
+            const string refPrefix = "ref: ";
+            if (reference.StartsWith(refPrefix + RefsPrefix, StringComparison.Ordinal))
+            {
+                name = reference.Substring(refPrefix.Length);
+                return true;
+            }
+
+            name = null;
+            return false;
         }
 
         /// <exception cref="IOException"/>
@@ -164,11 +185,8 @@ namespace Microsoft.Build.Tasks.Git
         {
             // See https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-HEAD
 
-            const string refPrefix = "ref: ";
-            if (reference.StartsWith(refPrefix + RefsPrefix, StringComparison.Ordinal))
+            if (TryGetReferenceName(reference, out string? symRef))
             {
-                var symRef = reference.Substring(refPrefix.Length);
-
                 if (lazyVisitedReferences != null && !lazyVisitedReferences.Add(symRef))
                 {
                     // infinite recursion

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -85,12 +85,14 @@ namespace Microsoft.Build.Tasks.Git
             ImmutableArray<GitSubmodule> submodules,
             ImmutableArray<string> submoduleDiagnostics,
             GitIgnore ignore,
-            string? headCommitSha)
+            string? headCommitSha,
+            string? branchName)
             : this(environment, config, gitDirectory, commonDirectory, workingDirectory)
         {
             _lazySubmodules = new Lazy<(ImmutableArray<GitSubmodule>, ImmutableArray<string>)>(() => (submodules, submoduleDiagnostics));
             _lazyIgnore = new Lazy<GitIgnore>(() => ignore);
             _lazyHeadCommitSha = new Lazy<string?>(() => headCommitSha);
+            _lazyBranchName = new Lazy<string?>(() => branchName);
         }        
 
         /// <summary>

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Build.Tasks.Git
         private readonly Lazy<(ImmutableArray<GitSubmodule> Submodules, ImmutableArray<string> Diagnostics)> _lazySubmodules;
         private readonly Lazy<GitIgnore> _lazyIgnore;
         private readonly Lazy<string?> _lazyHeadCommitSha;
+        private readonly Lazy<string?> _lazyBranchName;
         private readonly GitReferenceResolver _referenceResolver;
 
         internal GitRepository(GitEnvironment environment, GitConfig config, string gitDirectory, string commonDirectory, string? workingDirectory)
@@ -71,6 +72,7 @@ namespace Microsoft.Build.Tasks.Git
             _lazySubmodules = new Lazy<(ImmutableArray<GitSubmodule>, ImmutableArray<string>)>(ReadSubmodules);
             _lazyIgnore = new Lazy<GitIgnore>(LoadIgnore);
             _lazyHeadCommitSha = new Lazy<string?>(ReadHeadCommitSha);
+            _lazyBranchName = new Lazy<string?>(ReadBranchName);
         }
 
         // test only
@@ -180,6 +182,12 @@ namespace Microsoft.Build.Tasks.Git
         /// <exception cref="InvalidDataException"/>
         private string? ReadHeadCommitSha()
             => _referenceResolver.ResolveHeadReference();
+
+        public string? GetBranchName()
+            => _lazyBranchName.Value;
+
+        private string? ReadBranchName()
+            => _referenceResolver.GetBranchForHead();
 
         /// <summary>
         /// Creates <see cref="GitReferenceResolver"/> for a submodule located in the specified <paramref name="submoduleWorkingDirectoryFullPath"/>.

--- a/src/Microsoft.Build.Tasks.Git/GitOperations.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitOperations.cs
@@ -251,6 +251,7 @@ namespace Microsoft.Build.Tasks.Git
             {
                 // Don't report a warning since it has already been reported by GetRepositoryUrl task.
                 string? repositoryUrl = GetRepositoryUrl(repository, remoteName, logWarning: null);
+                string? branchName = repository.GetBranchName();
 
                 // Item metadata are stored msbuild-escaped. GetMetadata unescapes, SetMetadata stores the value as specified.
                 // Escape msbuild special characters so that URL escapes in the URL are preserved when the URL is read by GetMetadata.
@@ -259,6 +260,7 @@ namespace Microsoft.Build.Tasks.Git
                 item.SetMetadata(Names.SourceRoot.SourceControl, SourceControlName);
                 item.SetMetadata(Names.SourceRoot.ScmRepositoryUrl, Evaluation.ProjectCollection.Escape(repositoryUrl));
                 item.SetMetadata(Names.SourceRoot.RevisionId, revisionId);
+                item.SetMetadata(Names.SourceRoot.BranchName, Evaluation.ProjectCollection.Escape(branchName));
                 result.Add(item);
             }
             else if (warnOnMissingCommitOrUnsupportedUri)

--- a/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Build.Tasks.Git
         [Output]
         public string? RevisionId { get; private set; }
 
+        /// <summary>
+        /// Branch name.
+        /// </summary>
+        [Output]
+        public string? BranchName { get; private set; }
+
         protected override string? GetRepositoryId() => null;
         protected override string GetInitialPath() => Path!;
 
@@ -56,6 +62,7 @@ namespace Microsoft.Build.Tasks.Git
             Url = GitOperations.GetRepositoryUrl(repository, RemoteName, warnOnMissingOrUnsupportedRemote: !NoWarnOnMissingInfo, Log.LogWarning);
             Roots = GitOperations.GetSourceRoots(repository, RemoteName, warnOnMissingCommitOrUnsupportedUri: !NoWarnOnMissingInfo, Log.LogWarning);
             RevisionId = repository.GetHeadCommitSha();
+            BranchName = repository.GetBranchName();
         }
     }
 }

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -22,7 +22,7 @@
       Reports a warning if the given project doesn't belong to a repository under source control,
       unless the targets were implicily imported from an SDK without a package reference.
     -->
-    <Microsoft.Build.Tasks.Git.LocateRepository 
+    <Microsoft.Build.Tasks.Git.LocateRepository
       Path="$(MSBuildProjectDirectory)"
       RemoteName="$(GitRepositoryRemoteName)"
       ConfigurationScope="$(GitRepositoryConfigurationScope)"
@@ -32,7 +32,19 @@
       <Output TaskParameter="Url" PropertyName="ScmRepositoryUrl" />
       <Output TaskParameter="Roots" ItemName="SourceRoot" />
       <Output TaskParameter="RevisionId" PropertyName="SourceRevisionId" Condition="'$(SourceRevisionId)' == ''" />
+      <Output TaskParameter="BranchName" PropertyName="SourceBranchName" />
     </Microsoft.Build.Tasks.Git.LocateRepository>
+
+    <PropertyGroup>
+      <!--
+        This allows the SourceLink parameter to flow directly into the Pack task.
+
+        TODO: Should we do this here, or should we also make a change at
+        https://github.com/NuGet/NuGet.Client/blob/839df088f48e1e9d87ab86e5b26b7431547fa820/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L258
+        to map them in?
+      -->
+      <RepositoryBranch Condition="'$(RepositoryBranch)' == ''">$(SourceBranchName)</RepositoryBranch>
+    </PropertyGroup>
 
     <PropertyGroup>
       <RepositoryType Condition="'$(RepositoryType)' == ''">git</RepositoryType>

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -36,17 +36,6 @@
     </Microsoft.Build.Tasks.Git.LocateRepository>
 
     <PropertyGroup>
-      <!--
-        This allows the SourceLink parameter to flow directly into the Pack task.
-
-        TODO: Should we do this here, or should we also make a change at
-        https://github.com/NuGet/NuGet.Client/blob/839df088f48e1e9d87ab86e5b26b7431547fa820/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L258
-        to map them in?
-      -->
-      <RepositoryBranch Condition="'$(RepositoryBranch)' == ''">$(SourceBranchName)</RepositoryBranch>
-    </PropertyGroup>
-
-    <PropertyGroup>
       <RepositoryType Condition="'$(RepositoryType)' == ''">git</RepositoryType>
     </PropertyGroup>
   </Target>

--- a/src/SourceLink.Git.IntegrationTests/AzureDevOpsServerTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/AzureDevOpsServerTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -52,6 +53,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://tfs.{TestStrings.DomainName}.local:8080/tfs/DefaultCollection/project/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://tfs.{TestStrings.DomainName}.local:8080/tfs/DefaultCollection/project/_git/{repoName}",
                     $"https://tfs.{TestStrings.DomainName}.local:8080/tfs/DefaultCollection/project/_git/{repoName}",
@@ -101,6 +103,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -110,6 +113,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://tfs.{TestStrings.DomainName}.local/tfs/DefaultCollection/project/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://tfs.{TestStrings.DomainName}.local/tfs/DefaultCollection/project/_git/{repoName}",
                     $"https://tfs.{TestStrings.DomainName}.local/tfs/DefaultCollection/project/_git/{repoName}",

--- a/src/SourceLink.Git.IntegrationTests/AzureReposTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/AzureReposTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -52,6 +53,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://test.{host}/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://test.{host}/test-org/_git/{repoName}",
                     $"https://test.{host}/test-org/_git/{repoName}",
@@ -100,6 +102,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -109,6 +112,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://test.{host}/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://test.{host}/test-org/_git/{repoName}",
                     $"https://test.{host}/test-org/_git/{repoName}",

--- a/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -48,6 +49,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://api.bitbucket.org/2.0/repositories/test-org/{repoName}/src/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://bitbucket.org/test-org/{repoName}",
                     $"https://bitbucket.org/test-org/{repoName}"
@@ -98,6 +100,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -107,6 +110,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}"
@@ -155,6 +159,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -164,6 +169,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}.git",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}.git"
@@ -272,6 +278,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -281,6 +288,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/browse/*?at={commitSha}&raw",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}"
@@ -330,6 +338,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -339,6 +348,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://api.{TestStrings.DomainName}.com/2.0/repositories/test-org/{repoName}/src/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -388,6 +398,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -397,6 +408,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/projects/test-org/repos/{repoName}/browse/*?at={commitSha}&raw",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -446,6 +458,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -455,6 +468,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"

--- a/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
@@ -76,12 +76,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
                     "$(SourceLink)",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
                     "",
+                    // "refs/heads/main",
                 });
 
             Assert.False(File.Exists(sourceLinkFilePath));
@@ -105,7 +107,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 },
                 expectedResults: new[]
                 {
-                    NuGetPackageFolders
+                    NuGetPackageFolders,
                 },
                 expectedWarnings: new[]
                 {
@@ -145,6 +147,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -152,6 +155,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     "",
+                    // "refs/heads/main",
                     "",
                 });
         }
@@ -181,6 +185,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -188,6 +193,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
+                    // "refs/heads/main",
                     "",
                     "",
                 });
@@ -218,6 +224,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -225,6 +232,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     "",
+                    // "refs/heads/main",
                     "",
                 });
         }
@@ -281,6 +289,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)",
@@ -291,6 +300,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://github.com/test-org/{repoName}",
                     $"https://github.com/test-org/{repoName}",
@@ -340,6 +350,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -349,6 +360,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://test.{host}/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://test.{host}/test-org/_git/{repoName}",
                     $"https://test.{host}/test-org/_git/{repoName}",
@@ -382,6 +394,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -391,6 +404,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{host}/test/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{host}/test/test-org/_git/{repoName}",
                     $"https://{host}/test/test-org/_git/{repoName}",
@@ -415,11 +429,13 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot->'%(Identity):%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders + ":",
                     EnsureTrailingDirectorySeparator(ProjectDir.Path) + ":",
+                    "refs/heads/main",
                 },
                 expectedWarnings: new[]
                 {

--- a/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
@@ -76,14 +76,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "$(SourceLink)",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
                     "",
-                    // "refs/heads/main",
+                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                 });
 
             Assert.False(File.Exists(sourceLinkFilePath));
@@ -147,7 +147,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -155,7 +155,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     "",
-                    // "refs/heads/main",
+                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "",
                 });
         }
@@ -185,7 +185,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -193,7 +193,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
-                    // "refs/heads/main",
+                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "",
                     "",
                 });
@@ -224,7 +224,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Unclear what to do here since this test explicitly uses the SDK version of Microsoft.Build.Tasks.Git
+                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -232,7 +232,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     "",
-                    // "refs/heads/main",
+                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
                     "",
                 });
         }

--- a/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                 },
@@ -65,6 +66,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     SourceRoot,
                     $"https://raw.githubusercontent.com/test-org/test-repo2/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"http://github.com/test-org/test-repo2",
                 },
@@ -127,11 +129,13 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(PrivateRepositoryUrl)",
                 },
                 expectedResults: new[]
                 {
                     $"https://raw.githubusercontent.com/test-org/test-repo2/{commitSha}/*",
+                    "refs/heads/main",
                     $"http://github.com/test-org/test-repo2",
                 });
         }
@@ -159,11 +163,13 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(PrivateRepositoryUrl)",
                 },
                 expectedResults: new[]
                 {
                     $"https://raw.githubusercontent.com/test-org/test-repo1/{commitSha}/*",
+                    "refs/heads/main",
                     $"http://github.com/test-org/test-repo1",
                 },
                 expectedWarnings: new[]
@@ -198,6 +204,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -207,6 +214,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"http://github.com/test-org/{repoName}",
                     $"http://github.com/test-org/{repoName}"
@@ -254,6 +262,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -263,6 +272,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://github.com/test-org/{repoName}",
                     $"https://github.com/test-org/{repoName}"

--- a/src/SourceLink.Git.IntegrationTests/GitLabTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitLabTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -52,6 +53,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/-/raw/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -101,6 +103,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -110,6 +113,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/-/raw/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -155,12 +159,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 },
                 expressions: new[]
                 {
+                    "@(SourceRoot->'%(BranchName)')",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
                 },
                 expectedResults: new[]
                 {
+                    "refs/heads/main",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}/-/raw/{commitSha}/*",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}"

--- a/src/SourceLink.Git.IntegrationTests/GitWebTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitWebTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -55,6 +56,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/gitweb/?p={repoName};a=blob_plain;hb={commitSha};f=*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"ssh://git@{TestStrings.DomainName}.com/{repoNameFullyEscaped}",
                     $"ssh://git@{TestStrings.DomainName}.com/{repoNameFullyEscaped}"

--- a/src/SourceLink.Git.IntegrationTests/GiteaTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteaTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -52,6 +53,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/commit/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -101,6 +103,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -110,6 +113,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/commit/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -155,12 +159,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 },
                 expressions: new[]
                 {
+                    "@(SourceRoot->'%(BranchName)')",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
                 },
                 expectedResults: new[]
                 {
+                    "refs/heads/main",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}/raw/commit/{commitSha}/*",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}"

--- a/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -52,6 +53,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -101,6 +103,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     "@(SourceRoot)",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
@@ -110,6 +113,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/{commitSha}/*",
+                    "refs/heads/main",
                     s_relativeSourceLinkJsonPath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
@@ -155,12 +159,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 },
                 expressions: new[]
                 {
+                    "@(SourceRoot->'%(BranchName)')",
                     "@(SourceRoot->'%(SourceLinkUrl)')",
                     "$(PrivateRepositoryUrl)",
                     "$(RepositoryUrl)"
                 },
                 expectedResults: new[]
                 {
+                    "refs/heads/main",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}/raw/{commitSha}/*",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"http://{TestStrings.DomainName}.com/test-org/{repoName}"

--- a/src/SourceLink.Git.IntegrationTests/TargetTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/TargetTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(Test_DefaultEnableSourceControlManagerQueries)",
                     "$(Test_DefaultEnableSourceLink)",
                     "$(SourceLink)"
@@ -56,6 +57,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
+                    "refs/heads/main",
                     "true",
                     "true",
                     ""
@@ -83,6 +85,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(Test_DefaultEnableSourceControlManagerQueries)",
                     "$(Test_DefaultEnableSourceLink)",
                     "$(SourceLink)"
@@ -91,6 +94,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
+                    "refs/heads/main",
                     "true",
                     "",
                     ""
@@ -119,6 +123,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(Test_DefaultEnableSourceControlManagerQueries)",
                     "$(Test_DefaultEnableSourceLink)",
                     "$(SourceLink)"
@@ -127,6 +132,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
+                    "refs/heads/main",
                     "true",
                     "",
                     ""

--- a/src/SourceLink.Git.IntegrationTests/Utilities/GitUtilities.cs
+++ b/src/SourceLink.Git.IntegrationTests/Utilities/GitUtilities.cs
@@ -30,6 +30,9 @@ namespace Microsoft.SourceLink.IntegrationTests
 
                 repository.Index.Write();
                 repository.Commit("First commit", s_signature, s_signature);
+
+                // To avoid reliance on init.defaultBranch, rename the current branch to a known name.
+                repository.Branches.Rename(branch: repository.Head, newName: "main", allowOverwrite: true);
             }
 
             return repository;


### PR DESCRIPTION
Fixes #1243.

Adds `BranchName` as an output of the `LocateRepository` task and also adds it to the SourceRoot for the main repository. The locate task maps the `BranchName` output task to `SourceBranchName` in the .targets file to follow the naming convention. The branch is the full symbolic-ref name and not the short name to avoid ambiguity in source control systems like GitHub which use the `refs/pull` namespace for Pull Requests.

This change doesn't add branch name to submodules, as fundamentally submodules only track commits, and the main branch will fully specify any submodule-related metadata.

The corresponding change to map this value into `RepositoryBranch` as part of NuGet pack is @ https://github.com/NuGet/NuGet.Client/pull/5923.

Open issues in the PR:

1. [ ] Some of the `CloudHostedProvidersTests.cs` specifically use the inbox version of the Git tasks, and as such they can't assert the new functionality. I'm unsure if that's by design and I should not worry about that scenario, or if the tests should be changed?
2. [ ] Open to name changes anywhere; I went with the simple name, but happy to rename if there's something more appropriate.