### PR TITLE
Use Central Package Management

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,11 +17,6 @@
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
     <!-- runtime -->
     <SystemTextJsonVersion>7.0.3</SystemTextJsonVersion>
-    <!-- external -->
-    <MicrosoftTeamFoundationServerExtendedClientVersion>19.210.0-preview</MicrosoftTeamFoundationServerExtendedClientVersion>
-    <!-- libgit2 used for integration tests -->
-    <LibGit2SharpVersion>0.27.0-preview-0119</LibGit2SharpVersion>
-    <XunitCombinatorialVersion>1.5.25</XunitCombinatorialVersion>
   </PropertyGroup>
   <!-- msbuild (conditional due to https://github.com/dotnet/msbuild/issues/10492) -->
   <PropertyGroup Condition="'$(DotnetBuildFromSource)' == 'true'">

--- a/src/Common/GitProvider/Items.props
+++ b/src/Common/GitProvider/Items.props
@@ -10,7 +10,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <!-- Using multiple feeds isn't supported by Maestro: https://github.com/dotnet/arcade/issues/14155. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Command-line-api dependencies -->
+    <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="$(SystemCommandLineNamingConventionBinderVersion)" />
+    <PackageVersion Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
+
+    <!-- MSBuild dependencies -->
+    <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+
+    <!-- NuGet dependencies -->
+    <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
+
+    <!-- Runtime dependencies -->
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
+  <!-- External dependencies -->
+  <ItemGroup>
+    <!-- libgit2 used for integration tests -->
+    <PackageVersion Include="LibGit2Sharp" Version="0.27.0-preview-0119" />
+    <PackageVersion Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="19.210.0-preview" />
+    <PackageVersion Include="xunit.Combinatorial" version="1.5.25" />
+    <PackageVersion Include="xunit.assert" Version="$(XunitVersion)" Condition="'$(IsTestUtilityProject)' == 'true'" />
+    <PackageVersion Include="xunit.core" Version="$(XunitVersion)" Condition="'$(IsTestUtilityProject)' == 'true'" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Build.Tasks.Git/Microsoft.Build.Tasks.Git.csproj
+++ b/src/Microsoft.Build.Tasks.Git/Microsoft.Build.Tasks.Git.csproj
@@ -14,8 +14,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\Utilities\*.cs" Link="Common\%(FileName).cs" />

--- a/src/Microsoft.Build.Tasks.Tfvc/Microsoft.Build.Tasks.Tfvc.csproj
+++ b/src/Microsoft.Build.Tasks.Tfvc/Microsoft.Build.Tasks.Tfvc.csproj
@@ -15,9 +15,9 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="$(MicrosoftTeamFoundationServerExtendedClientVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\Utilities\*.cs" Link="Common\%(FileName).cs" />

--- a/src/SourceLink.AzureRepos.Tfvc/Microsoft.SourceLink.AzureRepos.Tfvc.csproj
+++ b/src/SourceLink.AzureRepos.Tfvc/Microsoft.SourceLink.AzureRepos.Tfvc.csproj
@@ -17,7 +17,7 @@
     <Compile Include="..\Common\Utilities\*.cs" Link="Common\%(FileName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
 </Project>

--- a/src/SourceLink.Common/Microsoft.SourceLink.Common.csproj
+++ b/src/SourceLink.Common/Microsoft.SourceLink.Common.csproj
@@ -14,8 +14,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\Utilities\*.cs" Link="Common\%(FileName).cs" />

--- a/src/SourceLink.Git.IntegrationTests/Microsoft.SourceLink.Git.IntegrationTests.csproj
+++ b/src/SourceLink.Git.IntegrationTests/Microsoft.SourceLink.Git.IntegrationTests.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
+    <PackageReference Include="LibGit2Sharp" />
     <ProjectReference Include="..\Microsoft.Build.Tasks.Git\Microsoft.Build.Tasks.Git.csproj" />
     <ProjectReference Include="..\SourceLink.Common\Microsoft.SourceLink.Common.csproj" />
     <ProjectReference Include="..\SourceLink.GitHub\Microsoft.SourceLink.GitHub.csproj" />

--- a/src/SourceLink.Tools.UnitTests/Microsoft.SourceLink.Tools.UnitTests.csproj
+++ b/src/SourceLink.Tools.UnitTests/Microsoft.SourceLink.Tools.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />

--- a/src/SourceLink.Tools/Microsoft.SourceLink.Tools.Package.csproj
+++ b/src/SourceLink.Tools/Microsoft.SourceLink.Tools.Package.csproj
@@ -17,6 +17,6 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>

--- a/src/TestUtilities/DotNetSdk/DotNetSdkTestBase.cs
+++ b/src/TestUtilities/DotNetSdk/DotNetSdkTestBase.cs
@@ -185,6 +185,13 @@ $@"<Project>
 </Project>
 ");
             RootDir.CreateFile("Directory.Build.targets").WriteAllText("<Project/>");
+            RootDir.CreateFile("Directory.Packages.props").WriteAllText(
+$@"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>
+");
             RootDir.CreateFile(".editorconfig").WriteAllText("root = true");
             RootDir.CreateFile("nuget.config").WriteAllText(GetLocalNuGetConfigContent(s_buildInfo.PackagesDirectory));
 

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -2,17 +2,16 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;$(NetCurrent)</TargetFrameworks>
-    <IsShipping>false</IsShipping>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
-    <PackageReference Include="xunit.Combinatorial" version="$(XunitCombinatorialVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.core" Version="$(XunitVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="NuGet.Versioning" />
+    <PackageReference Include="xunit.Combinatorial" />
+    <PackageReference Include="xunit.assert" />
+    <PackageReference Include="xunit.core" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/dotnet-sourcelink/dotnet-sourcelink.csproj
+++ b/src/dotnet-sourcelink/dotnet-sourcelink.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="$(SystemCommandLineNamingConventionBinderVersion)" />
-    <PackageReference Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" />
+    <PackageReference Include="System.CommandLine.Rendering" />
   </ItemGroup>
 
   <Import Project="..\SourceLink.Tools\Microsoft.SourceLink.Tools.projitems" Label="Shared" />


### PR DESCRIPTION
... and enable transitive pinning.

Define package dependencies in Directory.Packages.props. Set IsTestSupportProject in TestUtilities.csproj.