### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be the default owners for everything unless a later match takes precedence
+* @tmat @ViktorHofer


### PR DESCRIPTION
People without write access to the repo (like me) can't add reviewers directly. Instead, we must tag people for review, which is easy to miss under the volume of notifications.

I've added a `CODEOWNERS` file with PR approvers from the last 6 months (@tmat and @ViktorHofer).