### PR TITLE
Assert branch name now that SDK includes it

### DIFF
--- a/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
@@ -76,14 +76,14 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                 },
                 expectedResults: new[]
                 {
                     NuGetPackageFolders,
                     "",
-                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "",
                 });
 
             Assert.False(File.Exists(sourceLinkFilePath));
@@ -147,7 +147,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -155,7 +155,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     "",
-                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "",
                     "",
                 });
         }
@@ -185,7 +185,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -193,7 +193,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     ProjectSourceRoot,
-                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "refs/heads/main",
                     "",
                     "",
                 });
@@ -224,7 +224,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 expressions: new[]
                 {
                     "@(SourceRoot)",
-                    // "@(SourceRoot->'%(BranchName)')", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "@(SourceRoot->'%(BranchName)')",
                     "$(SourceLink)",
                     "@(_SourceLinkFileWrites)",
                 },
@@ -232,7 +232,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                 {
                     NuGetPackageFolders,
                     "",
-                    // "refs/heads/main", // TODO: Assert branch name once SDK has new SourceLink version https://github.com/dotnet/sourcelink/issues/1251
+                    "",
                     "",
                 });
         }


### PR DESCRIPTION
Fixes #1251

Now that the SDK includes #1248, uncomment the integration tests that explicitly use the SDK-provided version.

In a few cases the commented-out code was wrong, but those cases should be obvious (e.g. NoCommit tests).