### PR TITLE
Add Worktree_Packed_GetHeadCommitSha unit test

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
@@ -88,42 +88,6 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         }
 
         [Fact]
-        public void ResolveReference_Worktree_Packed()
-        {
-            using var temp = new TempRoot();
-            
-            string mainGitFolder = "worktreepackedtestmain";
-            string worktreeName = "worktreepackedtestchild";
-
-            var gitDir = temp.CreateDirectory(mainGitFolder);
-
-            gitDir.CreateFile("packed-refs").WriteAllText(
-@"# pack-refs with: peeled fully-peeled sorted
-1111111111111111111111111111111111111111 refs/heads/master
-2222222222222222222222222222222222222222 refs/heads/br2
-");
-            var commonDir = temp.CreateDirectory();
-            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
-            var worktreeDir = 
-
-            
-
-            var gitSubmoduleDir = temp.CreateDirectory(submoduleName);
-            gitSubmoduleDir
-
-            
-            
-
-            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
-
-            var resolver = new GitReferenceResolver(gitDir.Path, commonDir.Path);
-
-            Assert.Equal("1111111111111111111111111111111111111111", resolver.ResolveReference("ref: refs/heads/master"));
-            Assert.Equal("2222222222222222222222222222222222222222", resolver.ResolveReference("ref: refs/heads/br1"));
-            Assert.Equal("2222222222222222222222222222222222222222", resolver.ResolveReference("ref: refs/heads/br2"));
-        }
-
-        [Fact]
         public void ReadPackedReferences()
         {
             var packedRefs =

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
@@ -88,6 +88,42 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         }
 
         [Fact]
+        public void ResolveReference_Worktree_Packed()
+        {
+            using var temp = new TempRoot();
+            
+            string mainGitFolder = "worktreepackedtestmain";
+            string worktreeName = "worktreepackedtestchild";
+
+            var gitDir = temp.CreateDirectory(mainGitFolder);
+
+            gitDir.CreateFile("packed-refs").WriteAllText(
+@"# pack-refs with: peeled fully-peeled sorted
+1111111111111111111111111111111111111111 refs/heads/master
+2222222222222222222222222222222222222222 refs/heads/br2
+");
+            var commonDir = temp.CreateDirectory();
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+            var worktreeDir = 
+
+            
+
+            var gitSubmoduleDir = temp.CreateDirectory(submoduleName);
+            gitSubmoduleDir
+
+            
+            
+
+            var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
+
+            var resolver = new GitReferenceResolver(gitDir.Path, commonDir.Path);
+
+            Assert.Equal("1111111111111111111111111111111111111111", resolver.ResolveReference("ref: refs/heads/master"));
+            Assert.Equal("2222222222222222222222222222222222222222", resolver.ResolveReference("ref: refs/heads/br1"));
+            Assert.Equal("2222222222222222222222222222222222222222", resolver.ResolveReference("ref: refs/heads/br2"));
+        }
+
+        [Fact]
         public void ReadPackedReferences()
         {
             var packedRefs =

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRepositoryTests.cs
@@ -125,6 +125,46 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
         }
 
         [Fact]
+        public void Worktree_Packed_GetHeadCommitSha()
+        {
+            using var temp = new TempRoot();
+
+            var mainWorkingDir = temp.CreateDirectory();
+            var mainWorkingSubDir = mainWorkingDir.CreateDirectory("A");
+            var mainGitDir = mainWorkingDir.CreateDirectory(".git");
+            mainGitDir.CreateFile("HEAD");
+            mainGitDir.CreateFile("packed-refs").WriteAllText(
+@"# pack-refs with: peeled fully-peeled sorted
+1111111111111111111111111111111111111111 refs/heads/master
+2222222222222222222222222222222222222222 refs/heads/br2
+");
+
+            var worktreesDir = mainGitDir.CreateDirectory("worktrees");
+            var worktreeGitDir = worktreesDir.CreateDirectory("C");
+            var worktreeGitSubDir = worktreeGitDir.CreateDirectory("B");
+            var worktreeDir = temp.CreateDirectory();
+            var worktreeSubDir = worktreeDir.CreateDirectory("C");
+            var worktreeGitFile = worktreeDir.CreateFile(".git").WriteAllText("gitdir: " + worktreeGitDir + " \r\n\t\v");
+
+            worktreeGitDir.CreateFile("HEAD").WriteAllText("ref: refs/heads/br2\n");
+            worktreeGitDir.CreateFile("commondir").WriteAllText("../..\n");
+            worktreeGitDir.CreateFile("gitdir").WriteAllText(worktreeGitFile.Path + " \r\n\t\v");
+
+            // start under worktree directory:
+            Assert.True(GitRepository.TryFindRepository(worktreeSubDir.Path, out var location));
+            Assert.Equal(worktreeGitDir.Path, location.GitDirectory);
+            Assert.Equal(mainGitDir.Path, location.CommonDirectory);
+            Assert.Equal(worktreeDir.Path, location.WorkingDirectory);
+
+            var repository = GitRepository.OpenRepository(location, GitEnvironment.Empty);
+            Assert.Equal(location.GitDirectory, repository.GitDirectory);
+            Assert.Equal(location.WorkingDirectory, repository.WorkingDirectory);
+            Assert.Equal(location.CommonDirectory, repository.CommonDirectory);
+
+            Assert.Equal("2222222222222222222222222222222222222222", repository.GetHeadCommitSha());
+        }
+
+        [Fact]
         public void LocateRepository_Submodule()
         {
             using var temp = new TempRoot();


### PR DESCRIPTION
Add test covering situation where worktree refs are packed.
In this case none of the refs/ folders contain files with commit ids, they exist only in packed-refs file in main .git folder.
See #1290