### PR TITLE
Clean-up feeds and update MSBuild package version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,8 +5,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <!-- Feeds for command-line-api -->
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <!-- Feeds for source-build command-line-api intermediate -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,18 +13,12 @@
     <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
     <SystemCommandLineNamingConventionBinderVersion>2.0.0-beta4.23307.1</SystemCommandLineNamingConventionBinderVersion>
     <SystemCommandLineRenderingVersion>0.4.0-alpha.23307.1</SystemCommandLineRenderingVersion>
+    <!-- msbuild -->
+    <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
+    <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>
     <!-- nuget -->
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
     <!-- runtime -->
     <SystemTextJsonVersion>7.0.3</SystemTextJsonVersion>
-  </PropertyGroup>
-  <!-- msbuild (conditional due to https://github.com/dotnet/msbuild/issues/10492) -->
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <MicrosoftBuildVersion>17.3.4</MicrosoftBuildVersion>
-    <MicrosoftBuildTasksCoreVersion>17.3.4</MicrosoftBuildTasksCoreVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-    <MicrosoftBuildVersion>17.4.0</MicrosoftBuildVersion>
-    <MicrosoftBuildTasksCoreVersion>17.4.0</MicrosoftBuildTasksCoreVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Remove dotnet9 feeds
- Update MSBuild to 17.8.3 which is available on SBRP
- Remove accidentally checked-in file