### PR TITLE
Revert "update System.CommandLine (#1356)", but keep the removal of two dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.25072.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>060374e56c1b2e741b6525ca8417006efb54fbd7</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
+    </Dependency>
+    <Dependency Name="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.23307.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
+    </Dependency>
+    <Dependency Name="System.CommandLine.Rendering" Version="0.4.0-alpha.23307.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.607201">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>060374e56c1b2e741b6525ca8417006efb54fbd7</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,14 +5,6 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.23307.1">
-      <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
-    </Dependency>
-    <Dependency Name="System.CommandLine.Rendering" Version="0.4.0-alpha.23307.1">
-      <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
-    </Dependency>
     <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
       <Uri>https://github.com/dotnet/command-line-api</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- commandline -->
-    <SystemCommandLineVersion>2.0.0-beta4.25072.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
+    <SystemCommandLineNamingConventionBinderVersion>2.0.0-beta4.23307.1</SystemCommandLineNamingConventionBinderVersion>
+    <SystemCommandLineRenderingVersion>0.4.0-alpha.23307.1</SystemCommandLineRenderingVersion>
     <!-- msbuild -->
     <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,8 +11,6 @@
   <PropertyGroup>
     <!-- commandline -->
     <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
-    <SystemCommandLineNamingConventionBinderVersion>2.0.0-beta4.23307.1</SystemCommandLineNamingConventionBinderVersion>
-    <SystemCommandLineRenderingVersion>0.4.0-alpha.23307.1</SystemCommandLineRenderingVersion>
     <!-- msbuild -->
     <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>

--- a/src/dotnet-sourcelink/Program.cs
+++ b/src/dotnet-sourcelink/Program.cs
@@ -4,9 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.NamingConventionBinder;
-using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -64,11 +61,21 @@ namespace Microsoft.SourceLink.Tools
 
         private static CliRootCommand GetRootCommand()
         {
+            var pathArg = new CliArgument<string>("path")
+            {
+                Description = "Path to an assembly or .pdb"
+            };
             var authArg = new CliOption<string>("--auth", "-a")
             {
                 Description = "Authentication method"
             };
             authArg.AcceptOnlyFromAmong(AuthenticationMethod.Basic);
+
+            var authEncodingArg = new CliOption<Encoding>("--auth-encoding", "-e")
+            {
+                CustomParser = arg => Encoding.GetEncoding(arg.Tokens.Single().Value),
+                Description = "Encoding to use for authentication value"
+            };
 
             var userArg = new CliOption<string>("--user", "-u")
             {
@@ -89,48 +96,43 @@ namespace Microsoft.SourceLink.Tools
 
             var test = new CliCommand("test", "TODO")
             {
-                new CliArgument<string>("path")
-                {
-                    Description = "Path to an assembly or .pdb"
-                },
+                pathArg,
                 authArg,
-                new CliOption<Encoding>("--auth-encoding", "-e")
-                {
-                    CustomParser = arg => Encoding.GetEncoding(arg.Tokens.Single().Value),
-                    Description = "Encoding to use for authentication value"
-                },
+                authEncodingArg,
                 userArg,
                 passwordArg,
                 offlineArg,
             };
-            test.Action = CommandHandler.Create<string, string?, Encoding?, string?, string?, bool, ParseResult>(TestAsync);
+
+            test.SetAction((parseResult, cancellationToken) =>
+            {
+                string path = parseResult.GetValue(pathArg)!;
+                string? authMethod = parseResult.GetValue(authArg);
+                Encoding? authEncoding = parseResult.GetValue(authEncodingArg);
+                string? user = parseResult.GetValue(userArg);
+                string? password = parseResult.GetValue(passwordArg);
+                bool offline = parseResult.GetValue(offlineArg);
+
+                return TestAsync(path, authMethod, authEncoding, user, password, offline, parseResult, cancellationToken);
+            });
             
             var printJson = new CliCommand("print-json", "Print Source Link JSON stored in the PDB")
             {
-                new CliArgument<string>("path")
-                {
-                    Description = "Path to an assembly or .pdb"
-                }
+                pathArg
             };
-            printJson.Action = CommandHandler.Create<string, ParseResult>(PrintJsonAsync);
+            printJson.SetAction((parseResult, ct) => PrintJsonAsync(parseResult.GetValue(pathArg)!, parseResult));
 
             var printDocuments = new CliCommand("print-documents", "TODO")
             {
-                new CliArgument<string>("path")
-                {
-                    Description = "Path to an assembly or .pdb"
-                }
+                pathArg
             };
-            printDocuments.Action = CommandHandler.Create<string, ParseResult>(PrintDocumentsAsync);
+            printDocuments.SetAction((parseResult, ct) => PrintDocumentsAsync(parseResult.GetValue(pathArg)!, parseResult));
 
             var printUrls = new CliCommand("print-urls", "TODO")
             {
-                new CliArgument<string>("path")
-                {
-                    Description = "Path to an assembly or .pdb"
-                }
+                pathArg
             };
-            printUrls.Action = CommandHandler.Create<string, ParseResult>(PrintUrlsAsync);
+            printUrls.SetAction((parseResult, ct) => PrintUrlsAsync(parseResult.GetValue(pathArg)!, parseResult));
 
             var root = new CliRootCommand()
             {
@@ -176,20 +178,14 @@ namespace Microsoft.SourceLink.Tools
             string? user,
             string? password,
             bool offline,
-            ParseResult parseResult)
+            ParseResult parseResult,
+            CancellationToken cancellationToken)
         {
             var authenticationHeader = (authMethod != null) ? GetAuthenticationHeader(authMethod, authEncoding ?? Encoding.ASCII, user!, password!) : null;
 
-            var cancellationSource = new CancellationTokenSource();
-            Console.CancelKeyPress += (sender, e) =>
-            {
-                e.Cancel = true;
-                cancellationSource.Cancel();
-            };
-
             try
             {
-                return await new Program(parseResult).TestAsync(path, authenticationHeader, offline, cancellationSource.Token).ConfigureAwait(false);
+                return await new Program(parseResult).TestAsync(path, authenticationHeader, offline, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/dotnet-sourcelink/dotnet-sourcelink.csproj
+++ b/src/dotnet-sourcelink/dotnet-sourcelink.csproj
@@ -16,8 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" />
-    <PackageReference Include="System.CommandLine.Rendering" />
   </ItemGroup>
 
   <Import Project="..\SourceLink.Tools\Microsoft.SourceLink.Tools.projitems" Label="Shared" />

--- a/src/dotnet-sourcelink/dotnet-sourcelink.csproj
+++ b/src/dotnet-sourcelink/dotnet-sourcelink.csproj
@@ -16,6 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" />
+    <PackageReference Include="System.CommandLine.Rendering" />
   </ItemGroup>
 
   <Import Project="..\SourceLink.Tools\Microsoft.SourceLink.Tools.projitems" Label="Shared" />


### PR DESCRIPTION
This reverts commit 3c34adccbef5b95e680bc6e6424e3ebbbf4cd294 due to circular dependency between SDK and NuGet.Client that both use System.CommandLine. The update will be re-introduced around April.

But it keeps the changes responsible for removing dependencies to System.CommandLine.Rendering and System.CommandLine.NamingConventionBinder (we are not going to ship this libraries anymore and they were not used here so there is no point of keeping these dependencies).

cc @ViktorHofer 