### PR TITLE
Added \b escape character to config parsing as per spec

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitConfigTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitConfigTests.cs
@@ -350,6 +350,7 @@ a =
         [InlineData("name=\"a\rb\"", "name", "a\rb")]
         [InlineData("name=\"a\nb\"", "name", "a\nb")]
         [InlineData("name=\"a\r\nb\"", "name", "a\r\nb")]
+        [InlineData("name=\"a\bb\"", "name", "a\bb")]
         public void ReadVariableDeclaration(string str, string name, string value)
         {
             GitConfig.Reader.ReadVariableDeclaration(

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitConfig.Reader.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitConfig.Reader.cs
@@ -577,6 +577,14 @@ namespace Microsoft.Build.Tasks.Git
                                 lengthIgnoringTrailingWhitespace = builder.Length;
                                 continue;
 
+                            case 'b':
+                                reader.Read();
+                                builder.Append('\b');
+
+                                // escaped \b is not considered trailing whitespace:
+                                lengthIgnoringTrailingWhitespace = builder.Length;
+                                continue;
+
                             case '\\':
                             case '"':
                                 builder.Append((char)reader.Read());


### PR DESCRIPTION
Fixes: #1397

The Git documentation explicitly supports the `\b` escape character in quoted strings. This PR adds support for that.