### PR TITLE
Remove non-needed dotnet10 feeds from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,9 +5,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <!-- Feeds for packages built in the VMR (newly Arcade and other) -->
-    <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
-    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <!-- Feeds for command-line-api -->
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <!-- Feeds for source-build command-line-api intermediate -->


### PR DESCRIPTION
Those were necessary to restore packages from the VMR when it was only pushing to dotnet10 feeds. That's now fixed and i.e. Arcade packages from the VMR are now available in the dotnet-eng feed.