### PR TITLE
GitRepository: Support additional upstream extensions

### DIFF
--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRepository.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.Tasks.Git
         private const string GitModulesFileName = ".gitmodules";
 
         private static readonly ImmutableArray<string> s_knownExtensions =
-            ImmutableArray.Create("noop", "preciousObjects", "partialclone", "worktreeConfig");
+            ImmutableArray.Create("noop", "preciousObjects", "partialclone", "worktreeConfig", "objectFormat", "compatObjectFormat", "refstorage");
 
         public GitConfig Config { get; }
 


### PR DESCRIPTION
Upstream git is actively working on extensions that should be treated as known, even if they are currently experimental, as they do not break these targets.

`objectFormat` and `compatObjectFormat` are used to support SHA256 hashes: https://git-scm.com/docs/hash-function-transition

`refStorage` is used to support the new `reftable` binary storage backend: https://git-scm.com/docs/reftable

These extensions offer performance and security benefits, and we should expect to see more users trying them out before they become the default in git 3.0.

See https://about.gitlab.com/blog/what-s-new-in-git-2-51-0/#planning-towards-git-30 for details about what may be coming in git 3.0.

Fixes #1097.