### PR TITLE
[release/10.0.1xx] Condition OneLocBuild to only run for the main branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,10 @@ extends:
           publishAssetsImmediately: true
           isAssetlessBuild: true
           enableTelemetry: true
-      - template: /eng/common/templates-official/job/onelocbuild.yml@self
-        parameters:
-          MirrorRepo: sourcelink
-          LclSource: lclFilesfromPackage
-          LclPackageId: 'LCL-JUNO-PROD-SOURCELINK'
+      # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: sourcelink
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-SOURCELINK'


### PR DESCRIPTION
The OneLocBuild by default should only run on the main branch. If release branches need different localization, a separate package id needs to be created.

Thanks to the inter-branch-flow, this will automatically flow into release/10.0.2xx and then main.