### PR TITLE
[release/10.0.2xx] Make System.IO.Hashing a live dependency

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,11 +8,13 @@ This file should be imported by eng/Versions.props
     <!-- dotnet/dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.25571.105</MicrosoftDotNetArcadeSdkPackageVersion>
     <SystemCommandLinePackageVersion>2.0.0</SystemCommandLinePackageVersion>
+    <SystemIOHashingPackageVersion>10.0.0-rc.2.25502.107</SystemIOHashingPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>
     <!-- dotnet/dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
     <SystemCommandLineVersion>$(SystemCommandLinePackageVersion)</SystemCommandLineVersion>
+    <SystemIOHashingVersion>$(SystemIOHashingPackageVersion)</SystemIOHashingVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,24 +6,15 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>3a0c62bf027fbcb8683a13e78a5b21ae19028ca3</Sha>
     </Dependency>
+    <Dependency Name="System.IO.Hashing" Version="10.0.0-rc.2.25502.107">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>be28ec777bf12db631725399c442448d52093087</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25571.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>ae0ed89fe1caed1244d7633ba6e41cdd003023f7</Sha>
-    </Dependency>
-    <!-- Dependencies required for source build to lift to the previously-source-built version. -->
-    <Dependency Name="Microsoft.Build" Version="17.11.48">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>02bf66295b64ab368d12933041f7281aad186a2d</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.11.48">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>02bf66295b64ab368d12933041f7281aad186a2d</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Hashing" Version="10.0.0-rc.2.25502.107">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>be28ec777bf12db631725399c442448d52093087</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,6 @@
     <!-- nuget -->
     <NuGetVersioningVersion>6.12.1</NuGetVersioningVersion>
     <!-- runtime -->
-    <SystemIOHashingVersion>10.0.0</SystemIOHashingVersion>
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
and make Microsoft.Build* a truly static dependency for SB and MSFT build.

- MSFT build and SB should use the same version for MSBuild dependencies which is available on dotnet-public and SBRP.
- System.IO.Hashing gets redistributed in the sourcelink packages and the SDK and therefore needs to be a live dependency coming from runtime.

When this flows into the VMR, a RepositoryReference on runtime needs to be added here: https://github.com/dotnet/dotnet/blob/86ae7c196e35f767ab1d22e38b264e362d9ba6ea/repo-projects/sourcelink.proj#L11