### PR TITLE
Add RevisionTimestamp

### DIFF
--- a/src/Common/Utilities/Names.cs
+++ b/src/Common/Utilities/Names.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.Tasks.SourceControl
             public const string RepositoryUrl = nameof(RepositoryUrl);
             public const string ScmRepositoryUrl = nameof(ScmRepositoryUrl);
             public const string RevisionId = nameof(RevisionId);
+            public const string RevisionTimestamp = nameof(RevisionTimestamp);
             public const string ContainingRoot = nameof(ContainingRoot);
             public const string NestedRoot = nameof(NestedRoot);
             public const string MappedPath = nameof(MappedPath);
@@ -25,6 +26,7 @@ namespace Microsoft.Build.Tasks.SourceControl
             public const string RepositoryUrlFullName = nameof(SourceRoot) + "." + nameof(RepositoryUrl);
             public const string ScmRepositoryUrlFullName = nameof(SourceRoot) + "." + nameof(ScmRepositoryUrl);
             public const string RevisionIdFullName = nameof(SourceRoot) + "." + nameof(RevisionId);
+            public const string RevisionTimestampFullName = nameof(SourceRoot) + "." + nameof(RevisionTimestamp);
         }
     }
 }

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitOperationsTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             string? workingDir = null,
             GitConfig? config = null,
             string? commitSha = null,
+            DateTimeOffset? timestamp = null,
             string? branchName = null,
             ImmutableArray<GitSubmodule> submodules = default,
             GitIgnore? ignore = null)
@@ -41,6 +42,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
                 submoduleDiagnostics: ImmutableArray<string>.Empty,
                 ignore ?? new GitIgnore(root: null, workingDir, ignoreCase: false),
                 commitSha,
+                timestamp,
                 branchName);
         }
 

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitCommit.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitCommit.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Microsoft.Build.Tasks.Git
+{
+    internal sealed partial class GitCommit
+    {
+        public string Hash { get; }
+        public DateTimeOffset? CommitTimestamp { get; }
+
+        private GitCommit(string hash, DateTimeOffset? commitTimestamp)
+        {
+            Hash = hash;
+            CommitTimestamp = commitTimestamp;
+        }
+
+        internal static GitCommit FromHash(string GitDirectory, string hash)
+        {
+#if NET6_0_OR_GREATER
+            var directoryPath = hash[..2];
+            var filePath = hash[2..];
+            var commitObjectPath = Path.Combine(GitDirectory, "objects", directoryPath, filePath);
+            if (File.Exists(commitObjectPath))
+            {
+                using var fileStream = File.Open(commitObjectPath, FileMode.Open, FileAccess.Read);
+                using var zStream = new ZLibStream(fileStream, CompressionMode.Decompress);
+                using var memoryStream = new MemoryStream();
+                zStream.CopyTo(memoryStream);
+                var contents = Encoding.UTF8.GetString(memoryStream.ToArray());
+                var expectedMagic = "commit ";
+                if (!contents.StartsWith(expectedMagic, StringComparison.Ordinal))
+                {
+                    // TODO: Console.Write("Commit does not begin with magic string");
+                    return new GitCommit(hash, null);
+                }
+
+                int nullIndex = contents.IndexOf('\0', StringComparison.Ordinal);
+                if (nullIndex < 0)
+                {
+                    // TODO: Console.Write("Cound not find null");
+                    return new GitCommit(hash, null);
+                }
+
+                contents = contents[(nullIndex+1)..];
+
+                var lines = contents.Split('\n');
+                foreach (var line in lines)
+                {
+                    if (line.StartsWith("committer "))
+                    {
+                        var parts = line.Split(' ');
+                        var timestamp = parts[^2];
+                        var timezone = parts[^1];
+                        Console.WriteLine($"Found commit date: {timestamp} {timezone}");
+
+                        return new GitCommit(hash, ParseGitTimestamp(timestamp, timezone));
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+                // TODO: error: could not parse commit file
+                return new GitCommit(hash, null);
+            }
+            else
+            {
+                // TODO: Console.WriteLine("Could not find loose object with hash. Switching to searching in packed objects");
+                return new GitCommit(hash, null);
+            }
+#else
+            return new GitCommit(hash, null);
+#endif
+        }
+
+        private static DateTimeOffset? ParseGitTimestamp(string timestamp, string timezone)
+        {
+            var timestampLong = long.Parse(timestamp, CultureInfo.InvariantCulture);
+            var date = DateTimeOffset.FromUnixTimeSeconds(timestampLong);
+
+            var hours = int.Parse(timezone[1..3], CultureInfo.InvariantCulture);
+            var minutes = int.Parse(timezone[3..5], CultureInfo.InvariantCulture);
+            var offset = TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes);
+            if (timezone[0] == '-')
+            {
+                offset = offset.Negate();
+            }
+
+            return new DateTimeOffset(date.DateTime, offset);
+        }
+    }
+}

--- a/src/Microsoft.Build.Tasks.Git/GitOperations.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitOperations.cs
@@ -249,6 +249,8 @@ namespace Microsoft.Build.Tasks.Git
             var revisionId = repository.GetHeadCommitSha();
             if (revisionId != null)
             {
+                var revisionTimestamp = repository.GetHeadCommitTimestamp()?.ToString("O");
+
                 // Don't report a warning since it has already been reported by GetRepositoryUrl task.
                 var repositoryUrl = GetRepositoryUrl(repository, remoteName, logWarning: null);
                 var branchName = repository.GetBranchName();
@@ -260,6 +262,7 @@ namespace Microsoft.Build.Tasks.Git
                 item.SetMetadata(Names.SourceRoot.SourceControl, SourceControlName);
                 item.SetMetadata(Names.SourceRoot.ScmRepositoryUrl, Evaluation.ProjectCollection.Escape(repositoryUrl));
                 item.SetMetadata(Names.SourceRoot.RevisionId, revisionId);
+                item.SetMetadata(Names.SourceRoot.RevisionTimestamp, revisionTimestamp);
                 item.SetMetadata(Names.SourceRoot.BranchName, Evaluation.ProjectCollection.Escape(branchName));
                 result.Add(item);
             }

--- a/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
+++ b/src/Microsoft.Build.Tasks.Git/LocateRepository.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Build.Tasks.Git
         public string? RevisionId { get; private set; }
 
         /// <summary>
+        /// Head tip commit Timestamp.
+        /// </summary>
+        [Output]
+        public string? RevisionTimestamp { get; private set; }
+
+        /// <summary>
         /// Branch name.
         /// </summary>
         [Output]
@@ -62,6 +68,7 @@ namespace Microsoft.Build.Tasks.Git
             Url = GitOperations.GetRepositoryUrl(repository, RemoteName, warnOnMissingOrUnsupportedRemote: !NoWarnOnMissingInfo, Log.LogWarning);
             Roots = GitOperations.GetSourceRoots(repository, RemoteName, warnOnMissingCommitOrUnsupportedUri: !NoWarnOnMissingInfo, Log.LogWarning);
             RevisionId = repository.GetHeadCommitSha();
+            RevisionTimestamp = repository.GetHeadCommitTimestamp()?.ToString("O");
             BranchName = repository.GetBranchName();
         }
     }

--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
+++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.targets
@@ -32,6 +32,7 @@
       <Output TaskParameter="Url" PropertyName="ScmRepositoryUrl" />
       <Output TaskParameter="Roots" ItemName="SourceRoot" />
       <Output TaskParameter="RevisionId" PropertyName="SourceRevisionId" Condition="'$(SourceRevisionId)' == ''" />
+      <Output TaskParameter="RevisionTimeStamp" PropertyName="SourceRevisionTimeStamp" Condition="'$(SourceRevisionTimeStamp)' == ''" />
       <Output TaskParameter="BranchName" PropertyName="SourceBranchName" />
     </Microsoft.Build.Tasks.Git.LocateRepository>
 


### PR DESCRIPTION
Add a new MSBuild property called RevisionTimestamp that contains a timestamp indicating when the latest commit was added to git. This can then be used to timestamp the produced binaries (eg, dll files, file creation times of the contents of nuget packages) to make .NET builds and packages more deterministic/reproducible.

The timestamp is in the ISO 8601/RFC 3339 format, as generated by the "O" formatter.

Fixes: #1450