### PR TITLE
[release/10.0.1xx] Mark dotnet-sourcelink as non-shipping

### DIFF
--- a/src/dotnet-sourcelink/dotnet-sourcelink.csproj
+++ b/src/dotnet-sourcelink/dotnet-sourcelink.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetToolMinimum)</TargetFramework>
     <!-- Allow tool to roll forward to a newer major version. -->
     <RollForward>Major</RollForward>
 
+    <IsShipping>false</IsShipping>
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
     <PackAsTool>True</PackAsTool>


### PR DESCRIPTION
Will automatically forward flow into 2xx and main.