### PR TITLE
Use common dir to locate packed-refs and reftable

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitReferenceResolverTests.cs
@@ -106,13 +106,13 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             using var temp = new TempRoot();
 
             var gitDir = temp.CreateDirectory();
+            var commonDir = temp.CreateDirectory();
 
-            gitDir.CreateFile("packed-refs").WriteAllText(
+            commonDir.CreateFile("packed-refs").WriteAllText(
 @"# pack-refs with: peeled fully-peeled sorted
 1111111111111111111111111111111111111111 refs/heads/master
 2222222222222222222222222222222222222222 refs/heads/br2
 ");
-            var commonDir = temp.CreateDirectory();
             var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
 
             refsHeadsDir.CreateFile("br1").WriteAllText("ref: refs/heads/br2");
@@ -130,14 +130,14 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             using var temp = new TempRoot();
 
             var gitDir = temp.CreateDirectory();
+            var commonDir = temp.CreateDirectory();
 
             // Packed refs with SHA256 hashes (64 characters)
-            gitDir.CreateFile("packed-refs").WriteAllText(
+            commonDir.CreateFile("packed-refs").WriteAllText(
 @"# pack-refs with: peeled fully-peeled sorted
 1111111111111111111111111111111111111111111111111111111111111111 refs/heads/master
 2222222222222222222222222222222222222222222222222222222222222222 refs/heads/br2
 ");
-            var commonDir = temp.CreateDirectory();
             var refsHeadsDir = commonDir.CreateDirectory("refs").CreateDirectory("heads");
 
             refsHeadsDir.CreateFile("br1").WriteAllText("ref: refs/heads/br2");
@@ -230,7 +230,7 @@ namespace Microsoft.Build.Tasks.Git.UnitTests
             var gitDir = temp.CreateDirectory();
             var commonDir = temp.CreateDirectory();
 
-            var refTableDir = gitDir.CreateDirectory("reftable");
+            var refTableDir = commonDir.CreateDirectory("reftable");
 
             refTableDir.CreateFile("tables.list").WriteAllText("""
                 2.ref

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitReferenceResolver.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Build.Tasks.Git
             _commonDirectory = commonDirectory;
             _storageFormat = storageFormat;
             _objectNameFormat = objectNameFormat;
-            _lazyPackedReferences = new(() => ReadPackedReferences(_gitDirectory));
-            _lazyRefTableReferenceReaders = new(() => CreateRefTableReaders(_gitDirectory, _openedRefTableReaders));
+            _lazyPackedReferences = new(() => ReadPackedReferences(_commonDirectory));
+            _lazyRefTableReferenceReaders = new(() => CreateRefTableReaders(_commonDirectory, _openedRefTableReaders));
         }
 
         public void Dispose()
@@ -59,11 +59,15 @@ namespace Microsoft.Build.Tasks.Git
             }
         }
 
-        private ImmutableDictionary<string, string> ReadPackedReferences(string gitDirectory)
+        private ImmutableDictionary<string, string> ReadPackedReferences(string commonDirectory)
         {
             // https://git-scm.com/docs/git-pack-refs
 
-            var packedRefsPath = Path.Combine(gitDirectory, PackedRefsFileName);
+            // Although the above doc specifies 'packaged-refs' file is in GIT_DIR, 
+            // it is actually in the common directory as specified in
+            // https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-packed-refs
+
+            var packedRefsPath = Path.Combine(commonDirectory, PackedRefsFileName);
             if (!File.Exists(packedRefsPath))
             {
                 return ImmutableDictionary<string, string>.Empty;
@@ -174,9 +178,12 @@ namespace Microsoft.Build.Tasks.Git
 
         /// <exception cref="IOException"/>
         /// <exception cref="InvalidDataException"/>
-        private static IEnumerable<GitRefTableReader> CreateRefTableReaders(string gitDirectory, List<GitRefTableReader> openReaders)
+        private static IEnumerable<GitRefTableReader> CreateRefTableReaders(string commonDirectory, List<GitRefTableReader> openReaders)
         {
-            var refTableDirectory = Path.Combine(gitDirectory, RefTableDirectoryName);
+            // Although https://git-scm.com/docs/reftable#_layout specifies reftable to be in GIT_DIR,
+            // it is actually in the common directory. This is currently not documented.
+
+            var refTableDirectory = Path.Combine(commonDirectory, RefTableDirectoryName);
             var tablesFilePath = Path.Combine(refTableDirectory, TablesListFileName);
 
             // Create lazily-evaluated sequence of readers for each entry in the tables.list file (in reverse order).


### PR DESCRIPTION
The docs https://git-scm.com/docs/git-pack-refs say the `packed-refs` file is in `$GIT_DIR`, but it's actually in `$GIT_COMMON_DIR`. This is mentioned in https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-packed-refs.

Similarly, `reftable` is also located in `$GIT_COMMON_DIR` even though [the doc](https://git-scm.com/docs/reftable#_layout) says it's in `$GIT_DIR`.

Fixes https://github.com/dotnet/sourcelink/issues/1290
Includes https://github.com/dotnet/sourcelink/pull/1289 by @vikukush

