### PR TITLE
Fix interpretation of ref-index record block position

### DIFF
--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRefTableReaderTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRefTableReaderTests.cs
@@ -814,39 +814,39 @@ public class GitRefTableReaderTests
 
         using var reader = Create(writer);
 
-        var record = reader.SearchBlock(header, 0, "refs/heads/c");
+        var record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/c");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/c", record.Value.RefName);
         Assert.Equal("0300000000000000000000000000000000000000", record.Value.ObjectName);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/a");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/a");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/a", record.Value.RefName);
         Assert.Equal("0100000000000000000000000000000000000000", record.Value.ObjectName);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/b");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/b");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/b", record.Value.RefName);
         Assert.Equal("0200000000000000000000000000000000000000", record.Value.ObjectName);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/d");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/d");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/d", record.Value.RefName);
         Assert.Equal("0400000000000000000000000000000000000000", record.Value.ObjectName);
 
-        record = reader.SearchBlock(header, 0, "refs/heads");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads");
         Assert.Null(record);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/aa");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/aa");
         Assert.Null(record);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/bb");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/bb");
         Assert.Null(record);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/cc");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/cc");
         Assert.Null(record);
 
-        record = reader.SearchBlock(header, 0, "refs/heads/dd");
+        record = reader.SearchBlock(header, blockPosition: 0, "refs/heads/dd");
         Assert.Null(record);
     }
 

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRefTableReaderTests.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRefTableReaderTests.cs
@@ -802,7 +802,7 @@ public class GitRefTableReaderTests
             ObjectNameFormat = ObjectNameFormat.Sha1
         };
 
-        var refBlock1 = writer.WriteRefBlock(header: null,
+        var refBlock1 = writer.WriteRefBlock(header,
         [
             ("", "refs/heads/a", 0x01),
             ("refs/heads/", "b", 0x02),
@@ -810,50 +810,43 @@ public class GitRefTableReaderTests
             ("", "refs/heads/d", 0x04),
         ]);
 
+        Assert.Equal(0, refBlock1);
+
         using var reader = Create(writer);
 
-        writer.Position = refBlock1;
-        var record = reader.SearchBlock(header, "refs/heads/c");
+        var record = reader.SearchBlock(header, 0, "refs/heads/c");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/c", record.Value.RefName);
         Assert.Equal("0300000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/a");
+        record = reader.SearchBlock(header, 0, "refs/heads/a");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/a", record.Value.RefName);
         Assert.Equal("0100000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/b");
+        record = reader.SearchBlock(header, 0, "refs/heads/b");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/b", record.Value.RefName);
         Assert.Equal("0200000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/d");
+        record = reader.SearchBlock(header, 0, "refs/heads/d");
         Assert.NotNull(record);
         Assert.Equal("refs/heads/d", record.Value.RefName);
         Assert.Equal("0400000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads");
+        record = reader.SearchBlock(header, 0, "refs/heads");
         Assert.Null(record);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/aa");
+        record = reader.SearchBlock(header, 0, "refs/heads/aa");
         Assert.Null(record);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/bb");
+        record = reader.SearchBlock(header, 0, "refs/heads/bb");
         Assert.Null(record);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/cc");
+        record = reader.SearchBlock(header, 0, "refs/heads/cc");
         Assert.Null(record);
 
-        writer.Position = 0;
-        record = reader.SearchBlock(header, "refs/heads/dd");
+        record = reader.SearchBlock(header, 0, "refs/heads/dd");
         Assert.Null(record);
     }
 
@@ -924,85 +917,89 @@ public class GitRefTableReaderTests
 
         using var reader = Create(writer);
 
-        writer.Position = refIndexBlock3;
-        var record = reader.SearchBlock(header, "refs/heads/a");
+        var record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/a");
         Assert.NotNull(record);
         Assert.Equal("0100000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/b");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/b");
         Assert.NotNull(record);
         Assert.Equal("0200000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/c");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/c");
         Assert.NotNull(record);
         Assert.Equal("0300000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/d");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/d");
         Assert.NotNull(record);
         Assert.Equal("0400000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/e");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/e");
         Assert.NotNull(record);
         Assert.Equal("0500000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/f");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/f");
         Assert.NotNull(record);
         Assert.Equal("0600000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/g");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/g");
         Assert.NotNull(record);
         Assert.Equal("0700000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/h");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/h");
         Assert.NotNull(record);
         Assert.Equal("0800000000000000000000000000000000000000", record.Value.ObjectName);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/aa");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/aa");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/bb");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/bb");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/cc");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/cc");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/dd");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/dd");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/ee");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/ee");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/ff");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/ff");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/gg");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/gg");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/hh");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/hh");
         Assert.Null(record);
 
-        writer.Position = refIndexBlock3;
-        record = reader.SearchBlock(header, "refs/heads/z");
+        record = reader.SearchBlock(header, refIndexBlock3, "refs/heads/z");
         Assert.Null(record);
+    }
+
+    [Fact]
+    public void TryFindReference_Empty()
+    {
+        var writer = new GitRefTableTestWriter();
+
+        var header = new GitRefTableReader.Header()
+        {
+            Size = 24,
+            BlockSize = 1000,
+            ObjectNameFormat = ObjectNameFormat.Sha1
+        };
+
+        writer.WriteHeader(header);
+        writer.WriteFooter(header, 0);
+
+        using var reader = Create(writer);
+
+        Assert.False(reader.TryFindReference("refs/heads/c", out var objectName, out var symRef));
+        Assert.Null(symRef);
+        Assert.Null(objectName);
     }
 
     [Fact]

--- a/src/Microsoft.Build.Tasks.Git.UnitTests/GitRefTableTestWriter.cs
+++ b/src/Microsoft.Build.Tasks.Git.UnitTests/GitRefTableTestWriter.cs
@@ -243,8 +243,6 @@ internal class GitRefTableTestWriter
                 maxUpdate: 0);
         }
 
-        var blockTypePosition = Stream.Position;
-
         Stream.WriteByte((byte)kind);
 
         // uint24(block_len)
@@ -261,7 +259,7 @@ internal class GitRefTableTestWriter
 
         Stream.Position = blockEnd;
 
-        return blockTypePosition;
+        return blockStart;
     }
 
     public static byte[] GetObjectName(byte b0, ObjectNameFormat format = ObjectNameFormat.Sha1)

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRefTableReader.Diagnostics.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRefTableReader.Diagnostics.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DEBUG
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Tasks.Git;
+
+// Utilities for diagnosing reader issues.
+
+internal sealed partial class GitRefTableReader
+{
+    public record Block(
+        char Type,
+        long Position,
+        int UnalignedSize,
+        List<RefRecord> RefRecords,
+        List<RefIndexRecord> IndexRecords,
+        List<int> RestartOffsets)
+    {
+        public override string ToString()
+            => $"Type: '{Type}', Position: {Position}, UnalignedSize: {UnalignedSize}, Records: {RefRecords.Count + IndexRecords.Count}, RestartOffsets: {RestartOffsets.Count}";
+    }
+
+    /// <summary>
+    /// Returns all ref-blocks and ref-index-blocks.
+    /// </summary>
+    public List<Block> GetBlocks()
+    {
+        var footer = ReadHeaderAndFooter();
+
+        var blocks = new List<Block>();
+
+        Position = footer.Header.Size;
+        var blockStartPosition = 0L;
+
+        while (Position < footer.Position)
+        {
+            var blockType = ReadByte();
+            var unalignedSize = ReadUInt24BE();
+
+            var refRecords = new List<RefRecord>();
+            var indexRecords = new List<RefIndexRecord>();
+            var restartOffsets = new List<int>();
+
+            if (blockType is not (BlockTypeRef or BlockTypeIndex))
+            {
+                break;
+            }
+
+            var firstRecordPosition = Position;
+
+            Position = blockStartPosition + unalignedSize - sizeof(ushort);
+            var restartCount = ReadUInt16BE();
+            Position = firstRecordPosition;
+
+            var endOfRecords = blockStartPosition + unalignedSize - restartCount * SizeOfUInt24 - sizeof(ushort);
+            while (Position < endOfRecords)
+            {
+                if (blockType == BlockTypeRef)
+                {
+                    refRecords.Add(ReadRefRecord(footer.Header, priorName: null));
+                }
+                else
+                {
+                    indexRecords.Add(ReadRefIndexRecord(priorName: null));
+                }
+            }
+
+            for (var i = 0; i < restartCount; i++)
+            {
+                restartOffsets.Add(ReadUInt24BE());
+            }
+
+            // restart_count
+            _ = ReadUInt16BE();
+
+            blocks.Add(new Block((char)blockType, blockStartPosition, unalignedSize, refRecords, indexRecords, restartOffsets));
+
+            // If the file is unaligned the next block starts at the end of the current block,
+            // otherwise the current block is padded to block size and the next block starts after the padding.
+            blockStartPosition = footer.Header.BlockSize > 0 ? blockStartPosition + footer.Header.BlockSize : Position;
+
+            while (Position < blockStartPosition)
+            {
+                var padding = ReadByte();
+                if (padding != 0)
+                {
+                    throw new InvalidDataException($"Unexpected non-zero padding byte: 0x{padding:X2}.");
+                }
+            }
+        }
+
+        return blocks;
+    }
+}
+
+#endif

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRefTableReader.Structs.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRefTableReader.Structs.cs
@@ -26,6 +26,7 @@ internal sealed partial class GitRefTableReader
         public const int SizeExcludingHeader = 44;
 
         public Header Header { get; init; }
+        public long Position { get; init; }
         public long RefIndexPosition { get; init; }
     }
 
@@ -34,6 +35,23 @@ internal sealed partial class GitRefTableReader
         public string RefName { get; init; }
         public string? ObjectName { get; init; }
         public string? SymbolicRef { get; init; }
+
+        public override string ToString()
+        {
+            var str = $"RefName: '{RefName}'";
+
+            if (ObjectName != null)
+            {
+                str += $", ObjectName: '{ObjectName}'";
+            }
+
+            if (SymbolicRef != null)
+            {
+                str += $", SymbolicRef: '{SymbolicRef}'";
+            }
+
+            return str;
+        }
     }
 
     internal readonly struct RefIndexRecord
@@ -47,6 +65,9 @@ internal sealed partial class GitRefTableReader
         /// Position of leaf RefBlock or next level RefIndexBlock from the start of the file.
         /// </summary>
         public long BlockPosition { get; init; }
+
+        public override string ToString()
+            => $"LastRefName: '{LastRefName}', BlockPosition: {BlockPosition}";
     }
 
 }

--- a/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRefTableReader.cs
+++ b/src/Microsoft.Build.Tasks.Git/GitDataReader/GitRefTableReader.cs
@@ -56,18 +56,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
 
     private RefRecord? FindRefRecord(string referenceName)
     {
-        Position = 0;
-
-        // Readers are required to read header and validate version it before reading the footer.
-        // https://git-scm.com/docs/reftable#_footer
-        var header = ReadHeader();
-
-        var footerPosition = Length - header.Size - Footer.SizeExcludingHeader;
-
-        // Skip ahead to read the footer.
-        // It contains a copy of header and position of the RefIndex.
-        Position = footerPosition;
-        var footer = ReadFooter();
+        var footer = ReadHeaderAndFooter();
 
         if (footer.RefIndexPosition > 0)
         {
@@ -80,6 +69,12 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
             return SearchRefIndex(footer.Header, referenceName);
         }
 
+        // A reftable may be empty. In this case, the file starts with a header and is immediately followed by a footer.
+        if (footer.Position == footer.Header.Size)
+        {
+            return null;
+        }
+
         // No RefIndex, read RefBlocks sequentially.
 
         var blockStartPosition = 0L;
@@ -89,7 +84,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
             var isFirstBlock = blockStartPosition == 0;
 
             // The first block starts with header.
-            Position = blockStartPosition + (isFirstBlock ? header.Size : 0);
+            Position = blockStartPosition + (isFirstBlock ? footer.Header.Size : 0);
             switch (ReadByte())
             {
                 case BlockTypeRef:
@@ -109,13 +104,30 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
             }
 
             // If the file is unaligned the next block starts at the end of the current block,
-            // otherwise the current block its padded to block size and the next block starts after the padding.
+            // otherwise the current block is padded to block size and the next block starts after the padding.
             blockStartPosition = footer.Header.BlockSize > 0 ? blockStartPosition + footer.Header.BlockSize : blockEndPosition;
-            if (blockStartPosition >= footerPosition)
+            if (blockStartPosition >= footer.Position)
             {
                 return null;
             }
         }
+    }
+
+    // internal for testing
+    internal Footer ReadHeaderAndFooter()
+    {
+        Position = 0;
+
+        // Readers are required to read header and validate version it before reading the footer.
+        // https://git-scm.com/docs/reftable#_footer
+        var header = ReadHeader();
+
+        var footerPosition = Length - header.Size - Footer.SizeExcludingHeader;
+
+        // Skip ahead to read the footer.
+        // It contains a copy of header and position of the RefIndex.
+        Position = footerPosition;
+        return ReadFooter();
     }
 
     internal Header ReadHeader()
@@ -211,7 +223,8 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         return new Footer
         {
             Header = header,
-            RefIndexPosition = (long)refIndexPosition
+            Position = footerStartPosition,
+            RefIndexPosition = (long)refIndexPosition,
         };
     }
 
@@ -243,8 +256,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         if (firstGreater < 0)
         {
             // the last reference of the block is the one we are looking for:
-            Position = record.BlockPosition;
-            return SearchBlock(header, referenceName);
+            return SearchBlock(header, record.BlockPosition, referenceName);
         }
 
         // firstGreater points to the first record at a restart offset that contains references with last name larger than the searched value.
@@ -257,8 +269,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
 
             Debug.Assert(StringComparer.Ordinal.Compare(referenceName, record.LastRefName) < 0);
 
-            Position = record.BlockPosition;
-            var result = SearchBlock(header, referenceName);
+            var result = SearchBlock(header, record.BlockPosition, referenceName);
             if (result != null)
             {
                 return result;
@@ -284,8 +295,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
             if (StringComparer.Ordinal.Compare(referenceName, record.LastRefName) <= 0)
             {
                 // the last reference of the block is the one we are looking for:
-                Position = record.BlockPosition;
-                return SearchBlock(header, referenceName);
+                return SearchBlock(header, record.BlockPosition, referenceName);
             }
 
             priorName = record.LastRefName;
@@ -294,8 +304,11 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         return null;
     }
 
-    public RefRecord? SearchBlock(Header header, string referenceName)
+    public RefRecord? SearchBlock(Header header, long blockPosition, string referenceName)
     {
+        // first block's content is preceded by the header:
+        Position = blockPosition == 0 ? header.Size : blockPosition;
+
         return ReadByte() switch
         {
             BlockTypeRef => SearchRefBlock(header, referenceName, out _),
@@ -443,7 +456,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         return offsets;
     }
 
-    private (string name, byte valueType) ReadNameAndValueType(string priorName)
+    private (string name, byte valueType) ReadNameAndValueType(string? priorName)
     {
         // varint(prefix_length)
         var prefixLength = ReadVarInt();
@@ -457,7 +470,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         var suffixBytes = ReadBytes(suffixLength);
         try
         {
-            var name = priorName[0..prefixLength] + s_utf8.GetString(suffixBytes);
+            var name = priorName?[0..prefixLength] + s_utf8.GetString(suffixBytes);
             return (name, valueType);
         }
         catch
@@ -466,7 +479,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         }
     }
 
-    internal RefIndexRecord ReadRefIndexRecord(string priorName)
+    internal RefIndexRecord ReadRefIndexRecord(string? priorName)
     {
         var (name, valueType) = ReadNameAndValueType(priorName);
         if (valueType != 0)
@@ -484,7 +497,7 @@ internal sealed partial class GitRefTableReader(Stream stream) : IDisposable
         };
     }
 
-    internal RefRecord ReadRefRecord(Header header, string priorName)
+    internal RefRecord ReadRefRecord(Header header, string? priorName)
     {
         var (name, valueType) = ReadNameAndValueType(priorName);
 


### PR DESCRIPTION
The block position was incorrectly interpreted as position of the block type byte, but it's actually the position of the block start.
This distinction is significant for the first block because it contains the header and it's actual content starts after it.

The [spec](https://git-scm.com/docs/reftable) incorrectly implies that the `block_position` points to "block header":

>Index records store block_position after the suffix, specifying the absolute position in bytes (from the start of the file) of the block that ends with this reference. Readers can seek to block_position to begin reading the block header.
Readers must examine the block header at block_position to determine if the next block is another level index block, or the leaf-level ref block.


But other sections indicate that "block header" comprises of the block type and size.

Also fixes handling of empty reftable:

> A reftable may be empty. In this case, the file starts with a header and is immediately followed by a footer.

Fixes https://github.com/dotnet/sourcelink/issues/1674