### PR TITLE
[release/8.0.0] Port azure-pipelines-PR.yml and azure-pipelines.yml from release/9.0.0

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -1,0 +1,135 @@
+# Branches that trigger builds on PR
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    exclude:
+    - README.md
+    - docs/*
+
+# Run official build every day at midnight, if code has changed since the last run.
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily Official Build
+  branches:
+    include:
+    - main
+
+variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
+  - name: _TeamName
+    value: Roslyn
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        MirrorRepo: sourcelink
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-SOURCELINK'
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: true
+      enableTelemetry: true
+      enableSourceBuild: true
+      helixRepo: dotnet/symreader
+      jobs:
+      - job: Windows
+        pool:
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            vmImage: 'windows-latest'
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals 1es-windows-2022
+        variables:
+        # Only enable publishing in official builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+          - group: Publish-Build-Assets
+          - name: _OfficialBuildArgs
+            value: /p:DotNetSignType=$(_SignType)
+                  /p:DotNetPublishUsingPipelines=true
+                  /p:TeamName=$(_TeamName)
+                  /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        # else
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _OfficialBuildArgs
+            value: ''
+        strategy:
+          matrix:
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              Debug:
+                _BuildConfig: Debug
+                _SignType: test
+                _BuildArgs: ''
+            Release:
+              _BuildConfig: Release
+              # PRs or external builds are not signed.
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                _SignType: test
+                _BuildArgs: ''
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                _SignType: real
+                _BuildArgs: $(_OfficialBuildArgs)
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
+          displayName: Build and Test
+
+        # Archive NuGet packages to DevOps (workaround for https://github.com/dotnet/arcade/issues/4444)
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Artifact Packages
+          inputs:
+            PathtoPublish: 'artifacts\packages\$(_BuildConfig)'
+            ArtifactName: 'Packages'
+          condition: succeeded()
+
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        - job: MacOS
+          displayName: 'MacOS'
+          pool:
+            vmImage: 'macOS-latest'
+          strategy:
+            matrix:
+              Debug:
+                _BuildConfig: Debug
+                _SignType: none
+              Release:
+                _BuildConfig: Release
+                _SignType: none
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
+            displayName: Build and Test
+
+        - job: Linux
+          displayName: 'Linux'
+          pool:
+            vmImage: 'ubuntu-latest'
+          strategy:
+            matrix:
+              Debug:
+                _BuildConfig: Debug
+                _SignType: none
+              Release:
+                _BuildConfig: Release
+                _SignType: none
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
+            displayName: Build and Test
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng\common\templates\post-build\post-build.yml

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -41,7 +41,7 @@ stages:
       enablePublishUsingPipelines: true
       enableTelemetry: true
       enableSourceBuild: true
-      helixRepo: dotnet/symreader
+      helixRepo: dotnet/sourcelink
       jobs:
       - job: Windows
         pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,3 @@
-# Branches that trigger builds on PR
 pr:
   branches:
     include:
@@ -8,134 +7,124 @@ pr:
     exclude:
     - README.md
     - docs/*
-
-# Run official build every day at midnight, if code has changed since the last run.
 schedules:
 - cron: "0 0 * * *"
   displayName: Daily Official Build
   branches:
     include:
     - main
-
 variables:
-  - template: /eng/common/templates/variables/pool-providers.yml
-  - name: _TeamName
-    value: Roslyn
-
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: sourcelink
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-SOURCELINK'
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
-      enableTelemetry: true
-      enableSourceBuild: true
-      helixRepo: dotnet/symreader
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+- name: _TeamName
+  value: Roslyn
+- name: TeamName
+  value: Roslyn
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build
       jobs:
-      - job: Windows
-        pool:
-          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            vmImage: 'windows-latest'
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals 1es-windows-2022
-        variables:
-        # Only enable publishing in official builds
-        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
-          # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-          - group: Publish-Build-Assets
-          - name: _OfficialBuildArgs
-            value: /p:DotNetSignType=$(_SignType)
-                  /p:DotNetPublishUsingPipelines=true
-                  /p:TeamName=$(_TeamName)
-                  /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        # else
-        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: _OfficialBuildArgs
-            value: ''
-        strategy:
-          matrix:
-            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              Debug:
-                _BuildConfig: Debug
-                _SignType: test
-                _BuildArgs: ''
-            Release:
-              _BuildConfig: Release
-              # PRs or external builds are not signed.
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: sourcelink
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-SOURCELINK'
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enableMicrobuild: true
+          enablePublishBuildArtifacts: true
+          enablePublishTestResults: true
+          enablePublishBuildAssets: true
+          enablePublishUsingPipelines: true
+          enableTelemetry: true
+          enableSourceBuild: true
+          helixRepo: dotnet/symreader
+          jobs:
+          - job: Windows
+            pool:
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                _SignType: test
-                _BuildArgs: ''
+                vmImage: 'windows-latest'
               ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                _SignType: real
-                _BuildArgs: $(_OfficialBuildArgs)
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
-          displayName: Build and Test
-
-        # Archive NuGet packages to DevOps (workaround for https://github.com/dotnet/arcade/issues/4444)
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifact Packages
-          inputs:
-            PathtoPublish: 'artifacts\packages\$(_BuildConfig)'
-            ArtifactName: 'Packages'
-          condition: succeeded()
-
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - job: MacOS
-          displayName: 'MacOS'
-          pool:
-            vmImage: 'macOS-latest'
-          strategy:
-            matrix:
-              Debug:
-                _BuildConfig: Debug
-                _SignType: none
-              Release:
-                _BuildConfig: Release
-                _SignType: none
-          steps:
-          - checkout: self
-            clean: true
-          - script: eng/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
-            displayName: Build and Test
-
-        - job: Linux
-          displayName: 'Linux'
-          pool:
-            vmImage: 'ubuntu-latest'
-          strategy:
-            matrix:
-              Debug:
-                _BuildConfig: Debug
-                _SignType: none
-              Release:
-                _BuildConfig: Release
-                _SignType: none
-          steps:
-          - checkout: self
-            clean: true
-          - script: eng/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
-            displayName: Build and Test
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      # Symbol validation isn't being very reliable lately. This should be enabled back
-      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
-      enableSymbolValidation: false
+                name: $(DncEngInternalBuildPool)
+                demands: ImageOverride -equals 1es-windows-2022
+            variables:
+            - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              - group: Publish-Build-Assets
+              - name: _OfficialBuildArgs
+                value: /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              - name: _OfficialBuildArgs
+                value: ''
+            strategy:
+              matrix:
+                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                  Debug:
+                    _BuildConfig: Debug
+                    _SignType: test
+                    _BuildArgs: ''
+                Release:
+                  _BuildConfig: Release
+                  ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                    _SignType: test
+                    _BuildArgs: ''
+                  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                    _SignType: real
+                    _BuildArgs: $(_OfficialBuildArgs)
+            steps:
+            - checkout: self
+              clean: true
+            - script: eng\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
+              displayName: Build and Test
+          - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            - job: MacOS
+              displayName: 'MacOS'
+              pool:
+                vmImage: 'macOS-latest'
+              strategy:
+                matrix:
+                  Debug:
+                    _BuildConfig: Debug
+                    _SignType: none
+                  Release:
+                    _BuildConfig: Release
+                    _SignType: none
+              steps:
+              - checkout: self
+                clean: true
+              - script: eng/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
+                displayName: Build and Test
+            - job: Linux
+              displayName: 'Linux'
+              pool:
+                vmImage: 'ubuntu-latest'
+              strategy:
+                matrix:
+                  Debug:
+                    _BuildConfig: Debug
+                    _SignType: none
+                  Release:
+                    _BuildConfig: Release
+                    _SignType: none
+              steps:
+              - checkout: self
+                clean: true
+              - script: eng/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
+                displayName: Build and Test
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,24 +17,20 @@ variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 - name: _TeamName
   value: Roslyn
-- name: TeamName
-  value: Roslyn
 resources:
   repositories:
-  - repository: MicroBuildTemplate
+  - repository: 1ESPipelineTemplates
     type: git
-    name: 1ESPipelineTemplates/MicroBuildTemplate
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
     stages:
     - stage: build
       displayName: Build
@@ -54,7 +50,7 @@ extends:
           enablePublishUsingPipelines: true
           enableTelemetry: true
           enableSourceBuild: true
-          helixRepo: dotnet/symreader
+          helixRepo: dotnet/sourcelink
           jobs:
           - job: Windows
             pool:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,9 +30,9 @@
       <Sha>d9af20b993c474033098fe0851c2d71b4ecf434b</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23426.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
-      <Sha>194f32828726c3f1f63f79f3dc09b9e99c157b11</Sha>
+      <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>


### PR DESCRIPTION
Port the pipeline YAML files from release/9.0.0 to release/8.0.0:
- Add azure-pipelines-PR.yml (new file for PR builds)
- Update azure-pipelines.yml to use 1ES pipeline templates