### PR TITLE
Add [MSBuildMultiThreadableTask] to attribute-only SourceLink tasks

### DIFF
--- a/src/SourceLink.AzureDevOpsServer.Git/GetSourceLinkUrl.cs
+++ b/src/SourceLink.AzureDevOpsServer.Git/GetSourceLinkUrl.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.AzureDevOpsServer.Git
 {
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkAzureDevOpsServerGitHost";

--- a/src/SourceLink.AzureDevOpsServer.Git/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.AzureDevOpsServer.Git/TranslateRepositoryUrls.cs
@@ -3,10 +3,12 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.AzureDevOpsServer.Git
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
         // Translates

--- a/src/SourceLink.AzureRepos.Git/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.AzureRepos.Git/TranslateRepositoryUrls.cs
@@ -3,10 +3,12 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.AzureRepos.Git
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
         // Translates

--- a/src/SourceLink.Bitbucket.Git/GetSourceLinkUrl.cs
+++ b/src/SourceLink.Bitbucket.Git/GetSourceLinkUrl.cs
@@ -15,6 +15,7 @@ namespace Microsoft.SourceLink.Bitbucket.Git
     /// If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
     /// output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkBitbucketGitHost";

--- a/src/SourceLink.Bitbucket.Git/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.Bitbucket.Git/TranslateRepositoryUrls.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.Bitbucket.Git
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
     }

--- a/src/SourceLink.Common/SourceLinkHasSingleProvider.cs
+++ b/src/SourceLink.Common/SourceLinkHasSingleProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.SourceLink.Common
 {
+    [MSBuildMultiThreadableTask]
     public sealed class SourceLinkHasSingleProvider : Task
     {
         public string? ProviderTargets { get; set; }

--- a/src/SourceLink.GitHub/GetSourceLinkUrl.cs
+++ b/src/SourceLink.GitHub/GetSourceLinkUrl.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SourceLink.GitHub
     /// If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
     /// output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkGitHubHost";

--- a/src/SourceLink.GitHub/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.GitHub/TranslateRepositoryUrls.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.GitHub
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
     }

--- a/src/SourceLink.GitLab/GetSourceLinkUrl.cs
+++ b/src/SourceLink.GitLab/GetSourceLinkUrl.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SourceLink.GitLab
     /// If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
     /// output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkGitLabHost";

--- a/src/SourceLink.GitLab/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.GitLab/TranslateRepositoryUrls.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.GitLab
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
     }

--- a/src/SourceLink.GitWeb/GetSourceLinkUrl.cs
+++ b/src/SourceLink.GitWeb/GetSourceLinkUrl.cs
@@ -14,6 +14,7 @@ namespace Microsoft.SourceLink.GitWeb
     /// property is set to the content URL corresponding to the domain, otherwise it is set to
     /// string "N/A".
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkGitWebHost";

--- a/src/SourceLink.GitWeb/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.GitWeb/TranslateRepositoryUrls.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 using System;
 
@@ -13,6 +14,7 @@ namespace Microsoft.SourceLink.GitWeb
     /// <see cref="GetSourceLinkUrl"/> Task converts the URLs to HTTP content URLs which GitWeb does
     /// support. The output of this Task is independent of <see cref="GetSourceLinkUrl"/>.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
         /// <summary>

--- a/src/SourceLink.Gitea/GetSourceLinkUrl.cs
+++ b/src/SourceLink.Gitea/GetSourceLinkUrl.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SourceLink.Gitea
     /// If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
     /// output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkGiteaHost";

--- a/src/SourceLink.Gitea/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.Gitea/TranslateRepositoryUrls.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.Gitea
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
     }

--- a/src/SourceLink.Gitee/GetSourceLinkUrl.cs
+++ b/src/SourceLink.Gitee/GetSourceLinkUrl.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SourceLink.Gitee
     /// If the SourceRoot is associated with a git repository with a recognized domain the <see cref="SourceLinkUrl"/>
     /// output property is set to the content URL corresponding to the domain, otherwise it is set to string "N/A".
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetSourceLinkUrl : GetSourceLinkUrlGitTask
     {
         protected override string HostsItemGroupName => "SourceLinkGiteeHost";

--- a/src/SourceLink.Gitee/TranslateRepositoryUrls.cs
+++ b/src/SourceLink.Gitee/TranslateRepositoryUrls.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.SourceControl;
 
 namespace Microsoft.SourceLink.Gitee
 {
+    [MSBuildMultiThreadableTask]
     public sealed class TranslateRepositoryUrls : TranslateRepositoryUrlsGitTask
     {
     }


### PR DESCRIPTION
## Summary

Marks 16 concrete task classes as multithreaded-safe by adding the `[MSBuildMultiThreadableTask]` attribute. These tasks perform only pure URL/string manipulation with no file system, environment variable, or process operations in their `Execute()` path, so no `IMultiThreadableTask` implementation is needed.

## Migrated tasks (all attribute-only)

- `Microsoft.SourceLink.GitHub.GetSourceLinkUrl`
- `Microsoft.SourceLink.GitHub.TranslateRepositoryUrls`
- `Microsoft.SourceLink.GitLab.GetSourceLinkUrl`
- `Microsoft.SourceLink.GitLab.TranslateRepositoryUrls`
- `Microsoft.SourceLink.Bitbucket.Git.GetSourceLinkUrl`
- `Microsoft.SourceLink.Bitbucket.Git.TranslateRepositoryUrls`
- `Microsoft.SourceLink.AzureRepos.Git.TranslateRepositoryUrls`
- `Microsoft.SourceLink.Common.SourceLinkHasSingleProvider`
- `Microsoft.SourceLink.Gitea.GetSourceLinkUrl`
- `Microsoft.SourceLink.Gitea.TranslateRepositoryUrls`
- `Microsoft.SourceLink.Gitee.GetSourceLinkUrl`
- `Microsoft.SourceLink.Gitee.TranslateRepositoryUrls`
- `Microsoft.SourceLink.AzureDevOpsServer.Git.GetSourceLinkUrl`
- `Microsoft.SourceLink.AzureDevOpsServer.Git.TranslateRepositoryUrls`
- `Microsoft.SourceLink.GitWeb.GetSourceLinkUrl`
- `Microsoft.SourceLink.GitWeb.TranslateRepositoryUrls`

## Call-chain audit

Traced from `Execute()` through both base classes (`GetSourceLinkUrlGitTask`, `TranslateRepositoryUrlsGitTask`) to all leaves. The full transitive call graph reaches only:
- `Uri.TryCreate`, `string` manipulation, `UriUtilities.Combine/TryParseAuthority` (pure string/Uri)
- `AzureDevOpsUrlParser.TryParse*` (pure string/Uri parsing)
- `ITaskItem.GetMetadata/SetMetadata`, `Evaluation.ProjectCollection.Escape`
- `Log.LogError/LogWarning/LogMessage`

**Zero** file system, environment variable, process, Console, or static mutable state in any reachable leaf.

## Not migrated (tracked in https://github.com/dotnet/msbuild/issues/14093)

These tasks need full `IMultiThreadableTask` + `TaskEnvironment` migration:
- `Microsoft.SourceLink.AzureRepos.Git.GetSourceLinkUrl` — `Environment.GetEnvironmentVariable`
- `Microsoft.SourceLink.Common.GenerateSourceLinkFile` — `File.*` operations
- `Microsoft.Build.Tasks.Git.LocateRepository` — File I/O via GitRepository
- `Microsoft.Build.Tasks.Git.GetUntrackedFiles` — File I/O via GitRepository

## Testing

No new tests needed — attribute-only migrations on tasks with zero file/env/process interactions have no testable MT-specific behavior (a decoy-CWD test would pass identically with or without the attribute).