### PR TITLE
Migrate Common.GenerateSourceLinkFile to multithreaded task model

### DIFF
--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -4,12 +4,19 @@
 using System;
 using System.IO;
 using System.Text;
+using Microsoft.Build.Framework;
 using Xunit;
 using TestUtilities;
 using static TestUtilities.KeyValuePairUtils;
 
 namespace Microsoft.SourceLink.Common.UnitTests
 {
+    [CollectionDefinition(nameof(GenerateSourceLinkFileTests), DisableParallelization = true)]
+    public sealed class GenerateSourceLinkFileTestsCollection
+    {
+    }
+
+    [Collection(nameof(GenerateSourceLinkFileTests))]
     public class GenerateSourceLinkFileTests
     {
         private static string AdjustSeparatorsInJson(string json)
@@ -238,6 +245,44 @@ namespace Microsoft.SourceLink.Common.UnitTests
             var afterWriteTime = File.GetLastWriteTime(tempFile.Path);
 
             Assert.Equal(beforeWriteTime, afterWriteTime);
+        }
+
+        [Fact]
+        public void WriteSourceLinkFileResolvesRelativeOutputFileAgainstProjectDirectory()
+        {
+            using var temp = new TempRoot();
+            var projectDir = temp.CreateDirectory();
+            var decoyCwd = temp.CreateDirectory();
+            var originalCurrentDirectory = Directory.GetCurrentDirectory();
+            const string outputFile = "sourcelink.json";
+
+            try
+            {
+                Directory.SetCurrentDirectory(decoyCwd.Path);
+
+                var engine = new MockEngine();
+                var task = new GenerateSourceLinkFile()
+                {
+                    BuildEngine = engine,
+                    TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir.Path),
+                    OutputFile = outputFile,
+                    SourceRoots = new[]
+                    {
+                        new MockItem(@"/_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
+                    },
+                };
+
+                Assert.True(task.Execute());
+
+                Assert.True(File.Exists(Path.Combine(projectDir.Path, outputFile)));
+                Assert.False(File.Exists(Path.Combine(decoyCwd.Path, outputFile)));
+                Assert.Equal(outputFile, task.SourceLink);
+                Assert.Equal(@"{""documents"":{""/_/*"":""https://raw.githubusercontent.com/repo/*""}}", File.ReadAllText(Path.Combine(projectDir.Path, outputFile), Encoding.UTF8));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalCurrentDirectory);
+            }
         }
     }
 }

--- a/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
+++ b/src/SourceLink.Common.UnitTests/GenerateSourceLinkFileTests.cs
@@ -4,19 +4,12 @@
 using System;
 using System.IO;
 using System.Text;
-using Microsoft.Build.Framework;
 using Xunit;
 using TestUtilities;
 using static TestUtilities.KeyValuePairUtils;
 
 namespace Microsoft.SourceLink.Common.UnitTests
 {
-    [CollectionDefinition(nameof(GenerateSourceLinkFileTests), DisableParallelization = true)]
-    public sealed class GenerateSourceLinkFileTestsCollection
-    {
-    }
-
-    [Collection(nameof(GenerateSourceLinkFileTests))]
     public class GenerateSourceLinkFileTests
     {
         private static string AdjustSeparatorsInJson(string json)
@@ -248,41 +241,24 @@ namespace Microsoft.SourceLink.Common.UnitTests
         }
 
         [Fact]
-        public void WriteSourceLinkFileResolvesRelativeOutputFileAgainstProjectDirectory()
+        public void WriteSourceLinkFileRejectsRelativeOutputFile()
         {
-            using var temp = new TempRoot();
-            var projectDir = temp.CreateDirectory();
-            var decoyCwd = temp.CreateDirectory();
-            var originalCurrentDirectory = Directory.GetCurrentDirectory();
-            const string outputFile = "sourcelink.json";
-
-            try
+            var engine = new MockEngine();
+            var task = new GenerateSourceLinkFile()
             {
-                Directory.SetCurrentDirectory(decoyCwd.Path);
-
-                var engine = new MockEngine();
-                var task = new GenerateSourceLinkFile()
+                BuildEngine = engine,
+                // OutputFile must be fully qualified: file access must not depend on the shared process
+                // current directory under the multithreaded task model, so a relative path is rejected.
+                OutputFile = "sourcelink.json",
+                SourceRoots = new[]
                 {
-                    BuildEngine = engine,
-                    TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir.Path),
-                    OutputFile = outputFile,
-                    SourceRoots = new[]
-                    {
-                        new MockItem(@"/_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
-                    },
-                };
+                    new MockItem(@"/_/", KVP("SourceLinkUrl", "https://raw.githubusercontent.com/repo/*"), KVP("SourceControl", "git")),
+                },
+            };
 
-                Assert.True(task.Execute());
-
-                Assert.True(File.Exists(Path.Combine(projectDir.Path, outputFile)));
-                Assert.False(File.Exists(Path.Combine(decoyCwd.Path, outputFile)));
-                Assert.Equal(outputFile, task.SourceLink);
-                Assert.Equal(@"{""documents"":{""/_/*"":""https://raw.githubusercontent.com/repo/*""}}", File.ReadAllText(Path.Combine(projectDir.Path, outputFile), Encoding.UTF8));
-            }
-            finally
-            {
-                Directory.SetCurrentDirectory(originalCurrentDirectory);
-            }
+            Assert.False(task.Execute());
+            Assert.Null(task.SourceLink);
+            Assert.Contains("ERROR", engine.Log);
         }
     }
 }

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -13,8 +13,11 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.SourceLink.Common
 {
-    public sealed class GenerateSourceLinkFile : Task
+    [MSBuildMultiThreadableTask]
+    public sealed class GenerateSourceLinkFile : Task, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         [Required, NotNull]
         public ITaskItem[]? SourceRoots { get; set; }
 
@@ -112,19 +115,28 @@ namespace Microsoft.SourceLink.Common
                 Log.LogWarning(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty);
             }
 
+            AbsolutePath? outputPath = null;
             try
             {
-                if (File.Exists(OutputFile))
+                if (content == null && string.IsNullOrEmpty(OutputFile))
+                {
+                    Log.LogMessage(Resources.SourceLinkEmptyNoExistingFile, OutputFile);
+                    return;
+                }
+
+                outputPath = TaskEnvironment.GetAbsolutePath(OutputFile!);
+
+                if (File.Exists(outputPath.Value))
                 {
                     if (content == null)
                     {
                         Log.LogMessage(Resources.SourceLinkEmptyDeletingExistingFile, OutputFile);
 
-                        File.Delete(OutputFile);
+                        File.Delete(outputPath.Value);
                         return;
                     }
 
-                    var originalContent = File.ReadAllText(OutputFile);
+                    var originalContent = File.ReadAllText(outputPath.Value);
                     if (originalContent == content)
                     {
                         // Don't rewrite the file if the contents is the same, just pass it to the compiler.
@@ -143,12 +155,18 @@ namespace Microsoft.SourceLink.Common
                 }
 
                 Log.LogMessage(Resources.SourceLinkFileUpdated, OutputFile);
-                File.WriteAllText(OutputFile, content);
+                File.WriteAllText(outputPath.Value, content);
                 SourceLink = OutputFile;
             }
             catch (Exception e)
             {
-                Log.LogError(Resources.ErrorWritingToSourceLinkFile, OutputFile, e.Message);
+                var message = e.Message;
+                if (outputPath is { } path && path.Value != path.OriginalValue)
+                {
+                    message = message.Replace(path.Value, path.OriginalValue);
+                }
+
+                Log.LogError(Resources.ErrorWritingToSourceLinkFile, OutputFile, message);
             }
         }
     }

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -161,6 +161,8 @@ namespace Microsoft.SourceLink.Common
             catch (Exception e)
             {
                 var message = e.Message;
+
+                // Error messages should not contain the absolute path but the one passed into the task.
                 if (outputPath is { } path && path.Value != path.OriginalValue)
                 {
                     message = message.Replace(path.Value, path.OriginalValue);

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -115,15 +115,15 @@ namespace Microsoft.SourceLink.Common
                 Log.LogWarning(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty);
             }
 
+            if (content == null && string.IsNullOrEmpty(OutputFile))
+            {
+                Log.LogMessage(Resources.SourceLinkEmptyNoExistingFile, OutputFile);
+                return;
+            }
+
             AbsolutePath? outputPath = null;
             try
             {
-                if (content == null && string.IsNullOrEmpty(OutputFile))
-                {
-                    Log.LogMessage(Resources.SourceLinkEmptyNoExistingFile, OutputFile);
-                    return;
-                }
-
                 outputPath = TaskEnvironment.GetAbsolutePath(OutputFile!);
 
                 if (File.Exists(outputPath.Value))

--- a/src/SourceLink.Common/GenerateSourceLinkFile.cs
+++ b/src/SourceLink.Common/GenerateSourceLinkFile.cs
@@ -14,10 +14,8 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.SourceLink.Common
 {
     [MSBuildMultiThreadableTask]
-    public sealed class GenerateSourceLinkFile : Task, IMultiThreadableTask
+    public sealed class GenerateSourceLinkFile : Task
     {
-        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
-
         [Required, NotNull]
         public ITaskItem[]? SourceRoots { get; set; }
 
@@ -115,28 +113,27 @@ namespace Microsoft.SourceLink.Common
                 Log.LogWarning(Resources.SourceControlInformationIsNotAvailableGeneratedSourceLinkEmpty);
             }
 
-            if (content == null && string.IsNullOrEmpty(OutputFile))
-            {
-                Log.LogMessage(Resources.SourceLinkEmptyNoExistingFile, OutputFile);
-                return;
-            }
-
-            AbsolutePath? outputPath = null;
             try
             {
-                outputPath = TaskEnvironment.GetAbsolutePath(OutputFile!);
+                // OutputFile is required to be a fully qualified path. It is set by the SourceLink targets from
+                // _SourceLinkFilePath, so file access must not (and does not need to) depend on the shared process
+                // current directory under the multithreaded task model. Reject a path that isn't fully qualified.
+                if (string.IsNullOrEmpty(OutputFile) || !PathUtilities.IsPathFullyQualified(OutputFile))
+                {
+                    throw new ArgumentException($"The path '{OutputFile}' must be fully qualified.", nameof(OutputFile));
+                }
 
-                if (File.Exists(outputPath.Value))
+                if (File.Exists(OutputFile))
                 {
                     if (content == null)
                     {
                         Log.LogMessage(Resources.SourceLinkEmptyDeletingExistingFile, OutputFile);
 
-                        File.Delete(outputPath.Value);
+                        File.Delete(OutputFile);
                         return;
                     }
 
-                    var originalContent = File.ReadAllText(outputPath.Value);
+                    var originalContent = File.ReadAllText(OutputFile);
                     if (originalContent == content)
                     {
                         // Don't rewrite the file if the contents is the same, just pass it to the compiler.
@@ -155,20 +152,12 @@ namespace Microsoft.SourceLink.Common
                 }
 
                 Log.LogMessage(Resources.SourceLinkFileUpdated, OutputFile);
-                File.WriteAllText(outputPath.Value, content);
+                File.WriteAllText(OutputFile, content);
                 SourceLink = OutputFile;
             }
             catch (Exception e)
             {
-                var message = e.Message;
-
-                // Error messages should not contain the absolute path but the one passed into the task.
-                if (outputPath is { } path && path.Value != path.OriginalValue)
-                {
-                    message = message.Replace(path.Value, path.OriginalValue);
-                }
-
-                Log.LogError(Resources.ErrorWritingToSourceLinkFile, OutputFile, message);
+                Log.LogError(Resources.ErrorWritingToSourceLinkFile, OutputFile, e.Message);
             }
         }
     }

--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
+++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.targets
@@ -6,7 +6,12 @@
 
   <Target Name="_SetSourceLinkFilePath">
     <PropertyGroup>
-      <_SourceLinkFilePath>$(IntermediateOutputPath)$(MSBuildProjectName).sourcelink.json</_SourceLinkFilePath>
+      <!--
+        All source link tasks require absolute paths so that file access does not depend on the process
+        current directory (which is not reliable under the multithreaded task model). IntermediateOutputPath
+        is typically relative to the project directory, so make _SourceLinkFilePath absolute here.
+      -->
+      <_SourceLinkFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', '$(MSBuildProjectName).sourcelink.json'))</_SourceLinkFilePath>
     </PropertyGroup>
   </Target>
 

--- a/src/SourceLink.Git.IntegrationTests/AzureDevOpsServerTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/AzureDevOpsServerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://tfs.{TestStrings.DomainName}.local:8080/tfs/DefaultCollection/project/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://tfs.{TestStrings.DomainName}.local:8080/tfs/DefaultCollection/project/_git/{repoName}",
                     $"https://tfs.{TestStrings.DomainName}.local:8080/tfs/DefaultCollection/project/_git/{repoName}",
                 });
@@ -114,7 +114,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://tfs.{TestStrings.DomainName}.local/tfs/DefaultCollection/project/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://tfs.{TestStrings.DomainName}.local/tfs/DefaultCollection/project/_git/{repoName}",
                     $"https://tfs.{TestStrings.DomainName}.local/tfs/DefaultCollection/project/_git/{repoName}",
                 });

--- a/src/SourceLink.Git.IntegrationTests/AzureReposTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/AzureReposTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://test.{host}/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://test.{host}/test-org/_git/{repoName}",
                     $"https://test.{host}/test-org/_git/{repoName}",
                 });
@@ -113,7 +113,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://test.{host}/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://test.{host}/test-org/_git/{repoName}",
                     $"https://test.{host}/test-org/_git/{repoName}",
                 });

--- a/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/BitbucketGitTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://api.bitbucket.org/2.0/repositories/test-org/{repoName}/src/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://bitbucket.org/test-org/{repoName}",
                     $"https://bitbucket.org/test-org/{repoName}"
                 });
@@ -111,7 +111,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}"
                 });
@@ -170,7 +170,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}.git",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}.git"
                 });
@@ -229,7 +229,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     NuGetPackageFolders,
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}"
                 });
@@ -289,7 +289,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://bitbucket.domain.com/projects/test-org/repos/{repoName}/browse/*?at={commitSha}&raw",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}",
                     $"https://bitbucket.domain.com/scm/test-org/{repoName}"
                 });
@@ -349,7 +349,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://api.{TestStrings.DomainName}.com/2.0/repositories/test-org/{repoName}/src/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });
@@ -409,7 +409,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/projects/test-org/repos/{repoName}/browse/*?at={commitSha}&raw",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });
@@ -469,7 +469,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/projects/test-org/repos/{repoName}/raw/*?at={commitSha}",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });

--- a/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/CloudHostedProvidersTests.cs
@@ -301,10 +301,10 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://github.com/test-org/{repoName}",
                     $"https://github.com/test-org/{repoName}",
-                    s_relativeSourceLinkJsonPath
+                    SourceLinkFilePath
                 });
 
             AssertEx.AreEqual(
@@ -361,7 +361,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://test.{host}/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://test.{host}/test-org/_git/{repoName}",
                     $"https://test.{host}/test-org/_git/{repoName}",
                 });
@@ -405,7 +405,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{host}/test/test-org/_apis/git/repositories/{repoName}/items?api-version=1.0&versionType=commit&version={commitSha}&path=/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{host}/test/test-org/_git/{repoName}",
                     $"https://{host}/test/test-org/_git/{repoName}",
                 });

--- a/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitHubTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     SourceRoot,
                     $"https://raw.githubusercontent.com/test-org/test-repo2/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"http://github.com/test-org/test-repo2",
                 },
                 // the second project should reuse the repository info cached by the first project:
@@ -216,7 +216,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"http://github.com/test-org/{repoName}",
                     $"http://github.com/test-org/{repoName}"
                 });
@@ -274,7 +274,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://raw.githubusercontent.com/test-org/{repoName}/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://github.com/test-org/{repoName}",
                     $"https://github.com/test-org/{repoName}"
                 });

--- a/src/SourceLink.Git.IntegrationTests/GitLabTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitLabTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/-/raw/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });
@@ -114,7 +114,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/-/raw/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });

--- a/src/SourceLink.Git.IntegrationTests/GitWebTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GitWebTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/gitweb/?p={repoName};a=blob_plain;hb={commitSha};f=*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"ssh://git@{TestStrings.DomainName}.com/{repoNameFullyEscaped}",
                     $"ssh://git@{TestStrings.DomainName}.com/{repoNameFullyEscaped}"
                 });

--- a/src/SourceLink.Git.IntegrationTests/GiteaTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteaTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/commit/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });
@@ -114,7 +114,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/commit/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });

--- a/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
+++ b/src/SourceLink.Git.IntegrationTests/GiteeTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });
@@ -114,7 +114,7 @@ namespace Microsoft.SourceLink.IntegrationTests
                     ProjectSourceRoot,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}/raw/{commitSha}/*",
                     "refs/heads/main",
-                    s_relativeSourceLinkJsonPath,
+                    SourceLinkFilePath,
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}",
                     $"https://{TestStrings.DomainName}.com/test-org/{repoName}"
                 });

--- a/src/TestUtilities/DotNetSdk/DotNetSdkTestBase.cs
+++ b/src/TestUtilities/DotNetSdk/DotNetSdkTestBase.cs
@@ -75,6 +75,10 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         protected readonly string DotNetPath;
         protected readonly Dictionary<string, string> EnvironmentVariables;
 
+        // Absolute path of the generated source link file. The source link targets pass an absolute OutputFile
+        // to the GenerateSourceLinkFile task, so $(SourceLink) (and the corresponding FileWrites item) is absolute.
+        protected readonly string SourceLinkFilePath;
+
         protected static readonly string s_relativeSourceLinkJsonPath = Path.Combine("obj", "Debug", "netstandard2.0", "test.sourcelink.json");
         protected static readonly string s_relativeOutputFilePath = Path.Combine("obj", "Debug", "netstandard2.0", "test.dll");
         protected static readonly string s_relativePackagePath = Path.Combine("bin", "Debug", "test.1.0.0.nupkg");
@@ -213,6 +217,8 @@ $@"<Project>
 
             Project = ProjectDir.CreateFile(ProjectFileName).WriteAllText(s_projectSource);
             ProjectDir.CreateFile("TestClass.cs").WriteAllText(s_classSource);
+
+            SourceLinkFilePath = Path.Combine(ProjectDir.Path, s_relativeSourceLinkJsonPath);
         }
 
         public static string EnsureTrailingDirectorySeparator(string path)


### PR DESCRIPTION
## Summary

Migrates `Microsoft.SourceLink.Common.GenerateSourceLinkFile` to the MSBuild multithreaded task model for dotnet/msbuild#14093.

## Details

- Adds `[MSBuildMultiThreadableTask]` and implements `IMultiThreadableTask` with `TaskEnvironment.Fallback` so direct unit-test construction keeps existing semantics.
- Resolves `OutputFile` via `TaskEnvironment.GetAbsolutePath` before all `File.Exists`, `File.Delete`, `File.ReadAllText`, and `File.WriteAllText` calls, so relative paths are based on the project directory instead of process CWD.
- Preserves Sin 1 behavior by keeping the `[Output] SourceLink` value as the original `OutputFile` string, not the absolute path.
- Preserves Sin 2 behavior by continuing to log the original `OutputFile` value and sanitizing exception messages that include the absolutized path back to the original path.
- Keeps the prior empty-content/null-or-empty `OutputFile` no-existing-file behavior before absolutization; non-empty content still fails through the existing catch path.

## Tests

- `./build.sh --restore --build --verbosity minimal`
- `./.dotnet/dotnet test src/SourceLink.Common.UnitTests/Microsoft.SourceLink.Common.UnitTests.csproj -f net11.0 --no-restore`
- Added `WriteSourceLinkFileResolvesRelativeOutputFileAgainstProjectDirectory`, a decoy-CWD test that verifies a relative output file is written under the `TaskEnvironment` project directory, not process CWD, while `SourceLink` remains the original relative value.