### PR TITLE
Remove ViktorHofer from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything unless a later match takes precedence
-* @tmat @ViktorHofer
+* @tmat


### PR DESCRIPTION
I'm not an owner of this repo and don't want to get notified. This was already done in main but not in 10.0.